### PR TITLE
chore: avoid leaking sensitive data

### DIFF
--- a/internal/provider/httpTransport.go
+++ b/internal/provider/httpTransport.go
@@ -32,11 +32,12 @@ func (t *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	if err != nil {
 		fmt.Printf("Err:\n%s\n\n", err)
-	}
-	if t.EnableDebug && resp != nil {
-		// Log the response details
-		responseDump, _ := httputil.DumpResponse(resp, true)
-		fmt.Printf("Response:\n%s\n\n", responseDump)
+		
+		// only log the response details in case of error to avoid leaking sensitive data
+		if t.EnableDebug && resp != nil {
+			responseDump, _ := httputil.DumpResponse(resp, true)
+			fmt.Printf("Response:\n%s\n\n", responseDump)
+		}
 	}
 
 	return resp, err

--- a/internal/provider/httpTransport.go
+++ b/internal/provider/httpTransport.go
@@ -32,7 +32,7 @@ func (t *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	if err != nil {
 		fmt.Printf("Err:\n%s\n\n", err)
-		
+
 		// only log the response details in case of error to avoid leaking sensitive data
 		if t.EnableDebug && resp != nil {
 			responseDump, _ := httputil.DumpResponse(resp, true)


### PR DESCRIPTION
## About the changes
When using the provider with `TF_LOG=debug` we were outputting the responses which in the case of api-tokens it contains sensitive data. To prevent this, we're only going to log HTTP responses in the case of an error