### PR TITLE
feat: Import resources

### DIFF
--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -63,7 +63,7 @@ resource "unleash_role" "project_role" {
 
 ### Read-Only
 
-- `id` (Number) The id of this role.
+- `id` (String) The id of this role.
 
 <a id="nestedatt--permissions"></a>
 ### Nested Schema for `permissions`

--- a/internal/provider/api_token_resource.go
+++ b/internal/provider/api_token_resource.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	unleash "github.com/Unleash/unleash-server-api-go/client"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -16,9 +15,8 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource                = &apiTokenResource{}
-	_ resource.ResourceWithConfigure   = &apiTokenResource{}
-	_ resource.ResourceWithImportState = &apiTokenResource{}
+	_ resource.Resource              = &apiTokenResource{}
+	_ resource.ResourceWithConfigure = &apiTokenResource{}
 )
 
 // NewApiTokenResource is a helper function to simplify the provider implementation.
@@ -107,14 +105,6 @@ func (r *apiTokenResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 		},
 	}
-}
-
-func (r *apiTokenResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	tflog.Debug(ctx, "Preparing to import api token resource")
-
-	resource.ImportStatePassthroughID(ctx, path.Root("token_name"), req, resp)
-
-	tflog.Debug(ctx, "Finished importing api token data source", map[string]any{"success": true})
 }
 
 func (r *apiTokenResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -239,7 +229,7 @@ func (r *apiTokenResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 	var token unleash.ApiTokenSchema
 	for _, t := range tokens.Tokens {
-		if t.Secret == state.Secret.ValueString() || t.TokenName == state.TokenName.ValueString() {
+		if t.Secret == state.Secret.ValueString() {
 			token = t
 		}
 	}

--- a/internal/provider/api_token_resource.go
+++ b/internal/provider/api_token_resource.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	unleash "github.com/Unleash/unleash-server-api-go/client"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -110,10 +111,9 @@ func (r *apiTokenResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 
 func (r *apiTokenResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	tflog.Debug(ctx, "Preparing to import api token resource")
-	var state apiTokenResourceModel
 
-	// Set state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	resource.ImportStatePassthroughID(ctx, path.Root("token_name"), req, resp)
+
 	tflog.Debug(ctx, "Finished importing api token data source", map[string]any{"success": true})
 }
 
@@ -239,7 +239,7 @@ func (r *apiTokenResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 	var token unleash.ApiTokenSchema
 	for _, t := range tokens.Tokens {
-		if t.Secret == state.Secret.ValueString() {
+		if t.Secret == state.Secret.ValueString() || t.TokenName == state.TokenName.ValueString() {
 			token = t
 		}
 	}

--- a/internal/provider/project_access_resource.go
+++ b/internal/provider/project_access_resource.go
@@ -6,6 +6,7 @@ import (
 
 	unleash "github.com/Unleash/unleash-server-api-go/client"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -94,9 +95,9 @@ func (r *projectAccessResource) Schema(_ context.Context, _ resource.SchemaReque
 
 func (r *projectAccessResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	tflog.Debug(ctx, "Preparing to import projectAccess resource")
-	var state projectAccessResourceModel
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	resource.ImportStatePassthroughID(ctx, path.Root("project"), req, resp)
+
 	tflog.Debug(ctx, "Finished importing projectAccess data source", map[string]any{"success": true})
 }
 

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	unleash "github.com/Unleash/unleash-server-api-go/client"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -74,9 +75,9 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 
 func (r *projectResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	tflog.Debug(ctx, "Preparing to import project resource")
-	var state projectResourceModel
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+
 	tflog.Debug(ctx, "Finished importing project data source", map[string]any{"success": true})
 }
 

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -285,10 +285,9 @@ func (r *roleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	updateRoleSchema.CreateRoleWithPermissionsSchemaAnyOf = &roleWithPermissions
 
 	req.State.Get(ctx, &state) // the id is part of the state, not the plan, this is how we get its value
-	roleId := fmt.Sprintf("%v", state.Id)
+	roleId := state.Id.ValueString()
 	roleWithVersion, api_response, err := r.client.UsersAPI.UpdateRole(context.Background(), roleId).CreateRoleWithPermissionsSchema(updateRoleSchema).Execute()
 
-	role := roleWithVersion.Roles
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update role with id "+roleId,
@@ -305,6 +304,7 @@ func (r *roleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
+	role := roleWithVersion.Roles
 	state = roleResourceModel{
 		Id:   types.StringValue(fmt.Sprintf("%v", role.Id)),
 		Name: types.StringValue(role.Name),
@@ -343,7 +343,7 @@ func (r *roleResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	api_response, err := r.client.UsersAPI.DeleteRole(ctx, fmt.Sprintf("%v", state.Id)).Execute()
+	api_response, err := r.client.UsersAPI.DeleteRole(ctx, state.Id.ValueString()).Execute()
 
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -105,7 +105,7 @@ func (r *roleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 
 func (r *roleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	tflog.Debug(ctx, "Preparing to import role resource")
-	
+
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 
 	tflog.Debug(ctx, "Finished importing role resource", map[string]any{"success": true})

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	unleash "github.com/Unleash/unleash-server-api-go/client"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -99,10 +100,9 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 
 func (r *userResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	tflog.Debug(ctx, "Preparing to import user resource")
-	var state userResourceModel
-
-	// Set state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	
 	tflog.Debug(ctx, "Finished importing user data source", map[string]any{"success": true})
 }
 

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -100,9 +100,9 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 
 func (r *userResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	tflog.Debug(ctx, "Preparing to import user resource")
-	
+
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-	
+
 	tflog.Debug(ctx, "Finished importing user data source", map[string]any{"success": true})
 }
 


### PR DESCRIPTION
## About the changes
This implements import for all our resources. Some have been changed to simplify the import (e.g. making all IDs strings)

Some resources can only be imported knowing their id (e.g. users and roles). We could eventually import by username, email or role name, but that's beyond the scope of this PR 