### PR TITLE
docs: Add staged examples

### DIFF
--- a/examples/staged/.gitignore
+++ b/examples/staged/.gitignore
@@ -1,0 +1,4 @@
+terraform.tfstate
+terraform.tfstate.backup
+.terraform
+.terraform.lock.hcl

--- a/examples/staged/Makefile
+++ b/examples/staged/Makefile
@@ -1,0 +1,44 @@
+default: tests
+
+ifndef UNLEASH_DOCKER_IMAGE
+override UNLEASH_DOCKER_IMAGE = ghcr.io/ivarconr/unleash-enterprise:5.6.0-terraform-rc
+endif
+
+.PHONY: tests
+tests: clean start-docker
+	@echo "Running tests..."
+	@bash tests.sh
+	@echo "You can check the results at http://localhost:4242"
+	@echo "To clean up run 'make clean'"
+
+.PHONY: start-docker
+start-docker:
+	@echo "Starting docker..."
+	@UNLEASH_DOCKER_IMAGE=$(UNLEASH_DOCKER_IMAGE) docker compose up -d
+	@echo "Waiting for Unleash to be healthy..."
+	@while ! curl -s "http://localhost:4242/health"; do sleep 0.1; done
+	@echo "\nReady!"
+
+
+.PHONY: clean-docker
+clean-docker: 
+	@echo "Cleaning up docker..."
+	@docker compose stop && docker compose rm -f
+
+.PHONY: clean-state
+clean-state: 
+	@echo "Cleaning up Terraform state..."
+	@rm -f terraform.tfstate*
+
+.PHONY: clean-provider
+clean-provider: 
+	@echo "Cleaning up Terraform providers..."
+	@rm -rf stage_*/.terraform*
+
+.PHONY: set-provider
+set-provider: clean-provider
+	@echo "Setting Terraform provider to $(VERSION)"
+	@sed -i 's/^\(\s*\)version = ".*"/\1version = "$(VERSION)"/g' stage_*/provider.tf
+
+.PHONY: clean
+clean: clean-docker clean-state

--- a/examples/staged/README.md
+++ b/examples/staged/README.md
@@ -39,16 +39,16 @@ make TF_LOG=debug
 
 
 ## Stages
-### Stage 1
+### [Stage 1](./stage_1)
 Create a first project and a custom root roles
 
-### Stage 2
+### [Stage 2](./stage_2)
 Incorporates project roles and a few users.
 It also imports the default project that can then be used later on.
 
-### Stage 3
+### [Stage 3](./stage_3)
 Removes one user and creates some api tokens, modifies users and projects
 
-### Stage 4
+### [Stage 4](./stage_4)
 Reorganizes everything. It removes old projects and creates new ones. It also creates new users and api tokens.
 It defines a module to simplify the creation of projects and uses locals to declare what it wants to create.

--- a/examples/staged/README.md
+++ b/examples/staged/README.md
@@ -1,0 +1,54 @@
+# About this project
+This is a sample repo that shows the evolution of an Unleash installation from simple to a more complex one.
+
+If you just want to look at what Unleash managed with Terraform looks like, check out [stage 4](./stage_4)
+
+## How to use this repo
+### Prerequisites
+- [Terraform](https://www.terraform.io/downloads.html) >= 0.13
+- [Docker](https://docs.docker.com/get-docker/) >= 20.10.7
+- [Docker compose V2](https://docs.docker.com/compose/cli-command/) >= 2.0.0
+- [Bash](https://www.gnu.org/software/bash/) >= 5.1.8
+- Access to [Unleash Enterprise](https://www.unleash-hosted.com/) docker image
+
+### Running the steps
+A makefile makes it easy to run the steps. The steps are numbered and can be run in order. The steps are also described in the sections below.
+
+By default it will leave an instance of Unleash running at localhost:4242 so you can check the results. If you want to clean up the docker containers, run `make clean`.
+
+Note that every time you run make it will perform a cleanup before running the steps.
+
+* Run `make` to run all the steps
+```shell
+make
+```
+
+* Run each one of the steps individually (useful for debugging)
+```shell
+make STEPS="step_1"
+# or
+make STEPS="step_1 step_2"
+# because the steps are stateless, you can run them in any order (one by one or just execute any)
+make STEPS="step_4"
+```
+
+* Add debug information
+```shell
+make TF_LOG=debug
+```
+
+
+## Stages
+### Stage 1
+Create a first project and a custom root roles
+
+### Stage 2
+Incorporates project roles and a few users.
+It also imports the default project that can then be used later on.
+
+### Stage 3
+Removes one user and creates some api tokens, modifies users and projects
+
+### Stage 4
+Reorganizes everything. It removes old projects and creates new ones. It also creates new users and api tokens.
+It defines a module to simplify the creation of projects and uses locals to declare what it wants to create.

--- a/examples/staged/docker-compose.yml
+++ b/examples/staged/docker-compose.yml
@@ -1,6 +1,5 @@
 # This docker compose setup configures:
 # - the Unleash server instance + the necessary backing Postgres database
-# - the Unleash proxy
 #
 # To learn more about all the parts of Unleash, visit
 # https://docs.getunleash.io
@@ -19,11 +18,10 @@ services:
   unleash:
     image: ${UNLEASH_DOCKER_IMAGE:-unleashorg/unleash-server:latest}
     ports:
-      - "4242:4242" # TODO expose at random port (useful for testing)
+      - "4242:4242"
     environment:
       # This points Unleash to its backing database (defined in the `db` section below)
       DATABASE_URL: "postgres://postgres:unleash@db/unleash"
-      # Disable SSL for database connections. @chriswk: why do we do this?
       DATABASE_SSL: "false"
       # Changing log levels:
       LOG_LEVEL: "debug"

--- a/examples/staged/docker-compose.yml
+++ b/examples/staged/docker-compose.yml
@@ -1,0 +1,62 @@
+# This docker compose setup configures:
+# - the Unleash server instance + the necessary backing Postgres database
+# - the Unleash proxy
+#
+# To learn more about all the parts of Unleash, visit
+# https://docs.getunleash.io
+#
+# NOTE: please do not use this configuration for production setups.
+# Unleash does not take responsibility for any data leaks or other
+# problems that may arise as a result.
+#
+# This is intended to be used for demo, development, and learning
+# purposes only.
+
+version: "3.9"
+services:
+  # The Unleash server contains the Unleash configuration and
+  # communicates with server-side SDKs and the Unleash Proxy
+  unleash:
+    image: ${UNLEASH_DOCKER_IMAGE:-unleashorg/unleash-server:latest}
+    ports:
+      - "4242:4242" # TODO expose at random port (useful for testing)
+    environment:
+      # This points Unleash to its backing database (defined in the `db` section below)
+      DATABASE_URL: "postgres://postgres:unleash@db/unleash"
+      # Disable SSL for database connections. @chriswk: why do we do this?
+      DATABASE_SSL: "false"
+      # Changing log levels:
+      LOG_LEVEL: "debug"
+      # Admin token for testing only
+      INIT_ADMIN_API_TOKENS: "*:*.unleash-insecure-admin-api-token"
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:4242/health || exit 1
+      interval: 1s
+      timeout: 1m
+      retries: 5
+      start_period: 15s
+  db:
+    expose:
+      - "5432"
+    image: postgres:15
+    environment:
+      # create a database called `unleash`
+      POSTGRES_DB: "unleash"
+      # trust incoming connections blindly (DON'T DO THIS IN PRODUCTION!)
+      POSTGRES_HOST_AUTH_METHOD: "trust"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "pg_isready",
+          "--username=postgres",
+          "--host=127.0.0.1",
+          "--port=5432",
+        ]
+      interval: 2s
+      timeout: 1m
+      retries: 5
+      start_period: 10s

--- a/examples/staged/stage_1/main.tf
+++ b/examples/staged/stage_1/main.tf
@@ -1,0 +1,31 @@
+resource "unleash_project" "project_1" {
+  id          = "one"
+  name        = "First project"
+  description = "My first project"
+}
+
+resource "unleash_role" "gatekeeper_role" {
+  name        = "gatekeeper"
+  type        = "root-custom"
+  description = "The token guardian"
+  permissions = [
+    { "name" : "CREATE_CLIENT_API_TOKEN" },
+    { "name" : "UPDATE_CLIENT_API_TOKEN" },
+    { "name" : "DELETE_CLIENT_API_TOKEN" },
+    { "name" : "READ_CLIENT_API_TOKEN" },
+    { "name" : "CREATE_FRONTEND_API_TOKEN" },
+    { "name" : "UPDATE_FRONTEND_API_TOKEN" },
+    { "name" : "DELETE_FRONTEND_API_TOKEN" },
+    { "name" : "READ_FRONTEND_API_TOKEN" }
+  ]
+}
+
+resource "unleash_role" "tag_master" {
+  name        = "Tag master"
+  type        = "root-custom"
+  description = "This roles gives the ability to create and manage tags"
+  permissions = [
+    { "name" : "UPDATE_TAG_TYPE" },
+    { "name" : "DELETE_TAG_TYPE" }
+  ]
+}

--- a/examples/staged/stage_1/provider.tf
+++ b/examples/staged/stage_1/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    unleash = {
+      source  = "Unleash/unleash"
+      version = "1.0.0"
+    }
+  }
+}
+
+provider "unleash" {
+  base_url      = "http://localhost:4242"
+  authorization = "*:*.unleash-insecure-admin-api-token"
+}

--- a/examples/staged/stage_2/default_project.tf
+++ b/examples/staged/stage_2/default_project.tf
@@ -4,7 +4,7 @@ import {
 }
 
 resource "unleash_project" "default_project" {
-  id = "default"
-  name = "Taken over by Terraform"
+  id          = "default"
+  name        = "Taken over by Terraform"
   description = "This was default project"
 }

--- a/examples/staged/stage_2/default_project.tf
+++ b/examples/staged/stage_2/default_project.tf
@@ -1,0 +1,10 @@
+import {
+  id = "default"
+  to = unleash_project.default_project
+}
+
+resource "unleash_project" "default_project" {
+  id = "default"
+  name = "Taken over by Terraform"
+  description = "This was default project"
+}

--- a/examples/staged/stage_2/main.tf
+++ b/examples/staged/stage_2/main.tf
@@ -1,0 +1,85 @@
+resource "unleash_project" "project_1" {
+  id          = "one"
+  name        = "1st project" # standardize name
+  description = "Project one" # standardize description
+}
+
+resource "unleash_project" "project_2" {
+  id          = "two"
+  name        = "2nd project"
+  description = "Project two"
+}
+
+resource "unleash_role" "gatekeeper_role" {
+  name        = "gatekeeper"
+  type        = "root-custom"
+  description = "The token guardian without the ability of reading the keys"
+  permissions = [
+    { "name" : "CREATE_CLIENT_API_TOKEN" },
+    { "name" : "UPDATE_CLIENT_API_TOKEN" },
+    { "name" : "DELETE_CLIENT_API_TOKEN" },
+    { "name" : "CREATE_FRONTEND_API_TOKEN" },
+    { "name" : "UPDATE_FRONTEND_API_TOKEN" },
+    { "name" : "DELETE_FRONTEND_API_TOKEN" }
+  ]
+}
+
+resource "unleash_role" "tag_master" {
+  name        = "Tag master"
+  type        = "root-custom"
+  description = "This roles gives the ability to create and manage tags"
+  permissions = [
+    { "name" : "UPDATE_TAG_TYPE" },
+    { "name" : "DELETE_TAG_TYPE" }
+  ]
+}
+
+
+resource "unleash_role" "project_manager" {
+  name        = "Project manager"
+  type        = "custom"
+  description = "A custom project role"
+  permissions = [
+    { "name" : "CREATE_FEATURE" },
+    { "name" : "UPDATE_FEATURE" },
+    { "name" : "DELETE_FEATURE" },
+    { "name" : "UPDATE_PROJECT" }
+  ]
+}
+
+resource "unleash_role" "developer" {
+  name        = "Developer"
+  type        = "custom"
+  description = "A developer role"
+  permissions = [
+    { "name" : "CREATE_FEATURE_STRATEGY",
+    "environment" : "development" },
+    { "name" : "DELETE_FEATURE_STRATEGY",
+    "environment" : "development" },
+    { "name" : "UPDATE_FEATURE_STRATEGY",
+    "environment" : "development" },
+    { "name" : "UPDATE_FEATURE_ENVIRONMENT",
+    "environment" : "development" }
+  ]
+}
+
+resource "unleash_user" "dev1" {
+  email      = "dev1@getunleash.io"
+  name       = "dev_1"
+  root_role  = "3"
+  send_email = false
+}
+
+resource "unleash_user" "dev2" {
+  email      = "dev2@getunleash.io"
+  name       = "dev_2"
+  root_role  = "2"
+  send_email = false
+}
+
+resource "unleash_user" "dev3" {
+  email      = "dev3@getunleash.io"
+  name       = "dev_3"
+  root_role  = "1"
+  send_email = false
+}

--- a/examples/staged/stage_2/provider.tf
+++ b/examples/staged/stage_2/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    unleash = {
+      source  = "Unleash/unleash"
+      version = "1.0.0"
+    }
+  }
+}
+
+provider "unleash" {
+  base_url      = "http://localhost:4242"
+  authorization = "*:*.unleash-insecure-admin-api-token"
+}

--- a/examples/staged/stage_3/default_project.tf
+++ b/examples/staged/stage_3/default_project.tf
@@ -4,7 +4,7 @@ import {
 }
 
 resource "unleash_project" "default_project" {
-  id = "default"
-  name = "Taken over by Terraform"
+  id          = "default"
+  name        = "Taken over by Terraform"
   description = "This was default project"
 }

--- a/examples/staged/stage_3/default_project.tf
+++ b/examples/staged/stage_3/default_project.tf
@@ -1,0 +1,10 @@
+import {
+  id = "default"
+  to = unleash_project.default_project
+}
+
+resource "unleash_project" "default_project" {
+  id = "default"
+  name = "Taken over by Terraform"
+  description = "This was default project"
+}

--- a/examples/staged/stage_3/main.tf
+++ b/examples/staged/stage_3/main.tf
@@ -1,0 +1,112 @@
+resource "unleash_project" "project_1" {
+  id          = "one"
+  name        = "1st project" # standardize name
+  description = "Project one" # standardize description
+}
+
+resource "unleash_project" "project_2" {
+  id          = "two"
+  name        = "2nd project"
+  description = "Project two"
+}
+
+resource "unleash_role" "gatekeeper_role" {
+  name        = "gatekeeper"
+  type        = "root-custom"
+  description = "The token guardian without the ability of reading the keys"
+  permissions = [
+    { "name" : "CREATE_CLIENT_API_TOKEN" },
+    { "name" : "UPDATE_CLIENT_API_TOKEN" },
+    { "name" : "DELETE_CLIENT_API_TOKEN" },
+    { "name" : "CREATE_FRONTEND_API_TOKEN" },
+    { "name" : "UPDATE_FRONTEND_API_TOKEN" },
+    { "name" : "DELETE_FRONTEND_API_TOKEN" }
+  ]
+}
+
+resource "unleash_role" "tag_master" {
+  name        = "Tag master"
+  type        = "root-custom"
+  description = "This roles gives the ability to create and manage tags"
+  permissions = [
+    { "name" : "UPDATE_TAG_TYPE" },
+    { "name" : "DELETE_TAG_TYPE" }
+  ]
+}
+
+
+resource "unleash_role" "project_manager" {
+  name        = "Project manager"
+  type        = "custom"
+  description = "A custom project role"
+  permissions = [
+    { "name" : "CREATE_FEATURE" },
+    { "name" : "UPDATE_FEATURE" },
+    { "name" : "DELETE_FEATURE" },
+    { "name" : "UPDATE_PROJECT" }
+  ]
+}
+
+resource "unleash_role" "developer" {
+  name        = "Developer"
+  type        = "custom"
+  description = "A developer role"
+  permissions = [
+    { "name" : "CREATE_FEATURE_STRATEGY",
+    "environment" : "development" },
+    { "name" : "DELETE_FEATURE_STRATEGY",
+    "environment" : "development" },
+    { "name" : "UPDATE_FEATURE_STRATEGY",
+    "environment" : "development" },
+    { "name" : "UPDATE_FEATURE_ENVIRONMENT",
+    "environment" : "development" }
+  ]
+}
+
+resource "unleash_user" "dev1" {
+  email      = "dev1@getunleash.io"
+  name       = "dev_1"
+  root_role  = "3"
+  send_email = false
+}
+
+resource "unleash_user" "dev2" {
+  email      = "dev2@getunleash.io"
+  name       = "dev_2"
+  root_role  = "3" # dev2 should have been a viewer
+  send_email = false
+}
+
+# dev3 is gone
+
+resource "unleash_api_token" "client_token" {
+  token_name  = "dev_client_token"
+  type        = "client"
+  expires_at  = "2024-12-31T23:59:59Z"
+  project     = unleash_project.project_1.id
+  environment = "development"
+}
+
+resource "unleash_api_token" "client_token_prod" {
+  token_name  = "prod_client_token"
+  type        = "client"
+  expires_at  = "2024-12-31T23:59:59Z"
+  project     = unleash_project.project_1.id
+  environment = "production"
+}
+
+resource "unleash_api_token" "frontend_token" {
+  token_name  = "dev_frontend_token"
+  type        = "frontend"
+  expires_at  = "2024-12-31T23:59:59Z"
+  projects    = [unleash_project.project_1.id, unleash_project.project_2.id]
+  environment = "development"
+}
+
+resource "unleash_api_token" "admin_token" {
+  token_name  = "admin_token"
+  type        = "admin"
+  expires_at  = "2024-12-31T23:59:59Z"
+  projects    = ["*"]
+  environment = "*"
+}

--- a/examples/staged/stage_3/provider.tf
+++ b/examples/staged/stage_3/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    unleash = {
+      source  = "Unleash/unleash"
+      version = "1.0.0"
+    }
+  }
+}
+
+provider "unleash" {
+  base_url      = "http://localhost:4242"
+  authorization = "*:*.unleash-insecure-admin-api-token"
+}

--- a/examples/staged/stage_4/default_project.tf
+++ b/examples/staged/stage_4/default_project.tf
@@ -4,7 +4,7 @@ import {
 }
 
 resource "unleash_project" "default_project" {
-  id = "default"
-  name = "Taken over by Terraform"
+  id          = "default"
+  name        = "Taken over by Terraform"
   description = "This was default project"
 }

--- a/examples/staged/stage_4/default_project.tf
+++ b/examples/staged/stage_4/default_project.tf
@@ -1,0 +1,10 @@
+import {
+  id = "default"
+  to = unleash_project.default_project
+}
+
+resource "unleash_project" "default_project" {
+  id = "default"
+  name = "Taken over by Terraform"
+  description = "This was default project"
+}

--- a/examples/staged/stage_4/main.tf
+++ b/examples/staged/stage_4/main.tf
@@ -1,7 +1,7 @@
 locals {
   users = {
-    justin = "Justin Time"
-    ivan = "Ivan Issue"
+    justin  = "Justin Time"
+    ivan    = "Ivan Issue"
     winston = "Winston Golang"
   }
 
@@ -11,45 +11,45 @@ locals {
       tokens = [
         {
           environment = "development"
-          type = "client"
+          type        = "client"
         },
         {
           environment = "development"
-          type = "frontend"
+          type        = "frontend"
         }
       ]
       owner = unleash_user.users["justin"].id
-      users = [ "justin", "ivan" ]
+      users = ["justin", "ivan"]
     }
-     third = {
+    third = {
       name = "NullPointer's Paradise 2",
       tokens = [
         {
           environment = "development"
-          type = "client"
+          type        = "client"
         },
         {
           environment = "development"
-          type = "frontend"
+          type        = "frontend"
         }
       ]
       owner = unleash_user.users["justin"].id
-      users = [ "justin", "ivan" ]
+      users = ["justin", "ivan"]
     }
     second = {
       name = "BranchingOut",
       tokens = [
         {
           environment = "development"
-          type = "client"
+          type        = "client"
         },
         {
           environment = "production"
-          type = "client"
+          type        = "client"
         },
       ]
       owner = unleash_user.users["justin"].id
-      users = [ "ivan", "winston" ]
+      users = ["ivan", "winston"]
     }
   }
 }
@@ -57,12 +57,12 @@ locals {
 module "project" {
   for_each = local.projects
 
-  source = "./project"
-  id = each.key
-  name = each.value.name
-  tokens = each.value.tokens
+  source  = "./project"
+  id      = each.key
+  name    = each.value.name
+  tokens  = each.value.tokens
   members = [for u in each.value.users : unleash_user.users[u].id]
-  owner = each.value.owner
+  owner   = each.value.owner
 }
 
 resource "unleash_role" "gatekeeper_role" {

--- a/examples/staged/stage_4/main.tf
+++ b/examples/staged/stage_4/main.tf
@@ -1,0 +1,139 @@
+locals {
+  users = {
+    justin = "Justin Time"
+    ivan = "Ivan Issue"
+    winston = "Winston Golang"
+  }
+
+  projects = {
+    first = {
+      name = "NullPointer's Paradise",
+      tokens = [
+        {
+          environment = "development"
+          type = "client"
+        },
+        {
+          environment = "development"
+          type = "frontend"
+        }
+      ]
+      owner = unleash_user.users["justin"].id
+      users = [ "justin", "ivan" ]
+    }
+     third = {
+      name = "NullPointer's Paradise 2",
+      tokens = [
+        {
+          environment = "development"
+          type = "client"
+        },
+        {
+          environment = "development"
+          type = "frontend"
+        }
+      ]
+      owner = unleash_user.users["justin"].id
+      users = [ "justin", "ivan" ]
+    }
+    second = {
+      name = "BranchingOut",
+      tokens = [
+        {
+          environment = "development"
+          type = "client"
+        },
+        {
+          environment = "production"
+          type = "client"
+        },
+      ]
+      owner = unleash_user.users["justin"].id
+      users = [ "ivan", "winston" ]
+    }
+  }
+}
+
+module "project" {
+  for_each = local.projects
+
+  source = "./project"
+  id = each.key
+  name = each.value.name
+  tokens = each.value.tokens
+  members = [for u in each.value.users : unleash_user.users[u].id]
+  owner = each.value.owner
+}
+
+resource "unleash_role" "gatekeeper_role" {
+  name        = "gatekeeper"
+  type        = "root-custom"
+  description = "This role can create and manage API keys"
+  permissions = [
+    { "name" : "CREATE_CLIENT_API_TOKEN" },
+    { "name" : "UPDATE_CLIENT_API_TOKEN" },
+    { "name" : "DELETE_CLIENT_API_TOKEN" },
+    { "name" : "CREATE_FRONTEND_API_TOKEN" },
+    { "name" : "UPDATE_FRONTEND_API_TOKEN" },
+    { "name" : "DELETE_FRONTEND_API_TOKEN" }
+  ]
+}
+
+resource "unleash_role" "tag_master" {
+  name        = "Tag master"
+  type        = "root-custom"
+  description = "This roles gives the ability to create and manage tags"
+  permissions = [
+    { "name" : "UPDATE_TAG_TYPE" },
+    { "name" : "DELETE_TAG_TYPE" }
+  ]
+}
+
+resource "unleash_role" "project_manager" {
+  name        = "Project manager"
+  type        = "custom"
+  description = "A role that can control features inside a project"
+  permissions = [
+    { "name" : "CREATE_FEATURE" },
+    { "name" : "UPDATE_FEATURE" },
+    { "name" : "DELETE_FEATURE" },
+    { "name" : "UPDATE_PROJECT" }
+  ]
+}
+
+resource "unleash_role" "developer" {
+  name        = "Developer"
+  type        = "custom"
+  description = "A developer role"
+  permissions = [
+    { "name" : "CREATE_FEATURE_STRATEGY",
+    "environment" : "development" },
+    { "name" : "DELETE_FEATURE_STRATEGY",
+    "environment" : "development" },
+    { "name" : "UPDATE_FEATURE_STRATEGY",
+    "environment" : "development" },
+    { "name" : "UPDATE_FEATURE_ENVIRONMENT",
+    "environment" : "development" }
+  ]
+}
+
+data "unleash_role" "viewer" {
+  name = "Viewer"
+}
+
+resource "unleash_user" "users" {
+  for_each = local.users
+
+  email      = "${each.key}@getunleash.io"
+  name       = each.value
+  root_role  = data.unleash_role.viewer.id
+  send_email = false
+}
+
+resource "unleash_api_token" "admin_token" {
+  token_name  = "admin_token"
+  type        = "admin"
+  expires_at  = "2024-12-31T23:59:59Z"
+  projects    = ["*"]
+  environment = "*"
+}

--- a/examples/staged/stage_4/project/main.tf
+++ b/examples/staged/stage_4/project/main.tf
@@ -1,0 +1,72 @@
+terraform {
+  required_providers {
+    unleash = {
+      source  = "Unleash/unleash"
+    }
+  }
+}
+
+variable "id" {
+  description = "The id of the project."
+}
+
+variable "name" {
+  description = "The name of the project."
+}
+
+variable "owner" {
+  description = "The owner of the project."
+}
+
+variable "members" {
+  description = "List of ids of the members of the project."
+  default = []
+}
+
+variable "tokens" {
+  description = "List of tokens for the project."
+  default = []
+}
+
+resource "unleash_project" "projects" {
+  id          = var.id
+  name        = var.name
+  description = "Project ${var.id}: ${var.name}"
+}
+
+resource "unleash_api_token" "tokens" {
+  count = length(var.tokens)
+
+  depends_on  = [unleash_project.projects]
+  token_name  = "${var.id}-${var.tokens[count.index].environment}-${var.tokens[count.index].type}"
+  type        = var.tokens[count.index].type
+  expires_at  = "2024-12-31T23:59:59Z"
+  project     = var.id
+  environment = var.tokens[count.index].environment
+}
+
+data "unleash_role" "project_owner_role" {
+  name = "Owner"
+}
+
+data "unleash_role" "project_member_role" {
+  name = "Member"
+}
+
+resource "unleash_project_access" "access" {
+  project = var.id
+
+  depends_on  = [unleash_project.projects]
+  roles = [
+    {
+      role = data.unleash_role.project_owner_role.id
+      users = [var.owner]
+      groups = []
+    },
+    {
+      role = data.unleash_role.project_member_role.id
+      users = var.members
+      groups = []
+    },
+  ]
+}

--- a/examples/staged/stage_4/project/main.tf
+++ b/examples/staged/stage_4/project/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     unleash = {
-      source  = "Unleash/unleash"
+      source = "Unleash/unleash"
     }
   }
 }
@@ -20,12 +20,12 @@ variable "owner" {
 
 variable "members" {
   description = "List of ids of the members of the project."
-  default = []
+  default     = []
 }
 
 variable "tokens" {
   description = "List of tokens for the project."
-  default = []
+  default     = []
 }
 
 resource "unleash_project" "projects" {
@@ -56,16 +56,16 @@ data "unleash_role" "project_member_role" {
 resource "unleash_project_access" "access" {
   project = var.id
 
-  depends_on  = [unleash_project.projects]
+  depends_on = [unleash_project.projects]
   roles = [
     {
-      role = data.unleash_role.project_owner_role.id
-      users = [var.owner]
+      role   = data.unleash_role.project_owner_role.id
+      users  = [var.owner]
       groups = []
     },
     {
-      role = data.unleash_role.project_member_role.id
-      users = var.members
+      role   = data.unleash_role.project_member_role.id
+      users  = var.members
       groups = []
     },
   ]

--- a/examples/staged/stage_4/provider.tf
+++ b/examples/staged/stage_4/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    unleash = {
+      source  = "Unleash/unleash"
+      version = "1.0.0"
+    }
+  }
+}
+
+provider "unleash" {
+  base_url      = "http://localhost:4242"
+  authorization = "*:*.unleash-insecure-admin-api-token"
+}

--- a/examples/staged/tests.sh
+++ b/examples/staged/tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+# STAGES can be defined via env variable, e.g.: `make STAGES=stage_3` will just run stage 3
+if [ -z "$STAGES" ]; then
+    STAGES=$(ls | grep stage | sort)
+fi
+for STAGE in ${STAGES}; do
+    echo "================================================================="
+    echo "======================= Applying ${STAGE} ========================"
+    echo "================================================================="
+    cd ${STAGE}
+    terraform init # in case version was updated
+    terraform apply -state=../terraform.tfstate -auto-approve # using state from parent dir
+    cd ..
+done
+set +e


### PR DESCRIPTION
A set of examples that can be used to validate how Terraform can move Unleash config form stage to stage. This can be used for CI, but it can also be a starting point for a more simple & complete real-world example