### PR TITLE
chore: upgrade to latest image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
           - "1.3.*"
           - "1.4.*"
         docker-image:
-          - "ghcr.io/ivarconr/unleash-enterprise:5.6.0"
+          - "ghcr.io/ivarconr/unleash-enterprise:latest"
           - "unleashorg/unleash-server:latest"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
Just getting rid of the pre-release reference