### PR TITLE
feat: allow configuring auth token using UNLEASH_AUTH_TOKEN env

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -47,7 +47,7 @@ func (p *UnleashProvider) Metadata(ctx context.Context, req provider.MetadataReq
 
 func unleashClient(ctx context.Context, config *UnleashConfiguration, diagnostics *diag.Diagnostics) *unleash.APIClient {
 	base_url := strings.TrimSuffix(configValue(config.BaseUrl, "UNLEASH_URL"), "/")
-	authorization := configValue(config.Authorization, "AUTH_TOKEN")
+	authorization := configValue(config.Authorization, "AUTH_TOKEN", "UNLEASH_AUTH_TOKEN")
 	mustHave("base_url", base_url, diagnostics)
 	mustHave("authorization", authorization, diagnostics)
 
@@ -93,9 +93,13 @@ You can check a complete example [here](https://github.com/Unleash/terraform-pro
 	}
 }
 
-func configValue(configValue basetypes.StringValue, env string) string {
+func configValue(configValue basetypes.StringValue, envs ...string) string {
 	if configValue.IsNull() {
-		return os.Getenv(env)
+		for _, env := range envs {
+			if val := os.Getenv(env); val != "" {
+				return val
+			}
+		}
 	}
 	return configValue.ValueString()
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/stretchr/testify/assert"
 )
@@ -56,4 +57,16 @@ func Test_provider_checkIsSupportedVersion_560(t *testing.T) {
 	var diags diag.Diagnostics
 	CheckIsSupportedVersion("5.6.0", &diags)
 	assert.False(t, diags.HasError())
+}
+
+func Test_provider_configValue(t *testing.T) {
+	t.Setenv("FOO", "foo")
+	t.Setenv("BAR", "bar")
+	t.Setenv("BAZ", "baz")
+	assert.Equal(t, "foo", configValue(types.StringValue("foo"), "BAR"))
+	assert.Equal(t, "", configValue(types.StringNull(), "SOME_ENV"))
+	assert.Equal(t, "bar", configValue(types.StringNull(), "BAR"))
+	assert.Equal(t, "bar", configValue(types.StringNull(), "BAR", "BAZ"))
+	assert.Equal(t, "baz", configValue(types.StringNull(), "QUX", "BAZ"))
+	assert.Equal(t, "bar", configValue(types.StringNull(), "QUX", "BAR", "BAZ"))
 }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
This change introduces the possibility of configuring the auth token using `UNLEASH_AUTH_TOKEN`, instead of `AUTH_TOKEN`. This is useful when using a bunch of providers, to be able to more easily keep track of which env variables are used where, and avoid conflicts with other providers.

<!-- Does it close an issue? Multiple? -->
Closes #90

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
To avoid a breaking change I changed the `configValue` so it cloud take multiple values for env variables, and "selects" the first non-empty one. I also saw that `configValue.ValueString()` returns `""` when `configValue.IsNull() == true` (for the case where no env variable is set and `configValue.IsNull() == true`), so I think it still keeps its old behaviour.

Maybe the more "specific" `UNLEASH_AUTH_TOKEN` should be before `AUTH_TOKEN` so the more specific version if prioritized, in case another provider uses the `AUTH_TOKEN` variable?