### PR TITLE
feat: implement data source and resource for project environments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/Masterminds/semver v1.5.0
-	github.com/Unleash/unleash-server-api-go v0.5.3
+	github.com/Unleash/unleash-server-api-go v0.5.4
 	github.com/fatih/structs v1.1.0
 	github.com/hashicorp/terraform-plugin-docs v0.18.0
 	github.com/hashicorp/terraform-plugin-framework v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBa
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX7IL/m9Y5LO+KQYv+t1CQOiFe6+SV2J7bE=
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
-github.com/Unleash/unleash-server-api-go v0.5.3 h1:CbWFE9eK5PVKXwpvKRYratuO/75ZtEqavMu6Sc0y4To=
-github.com/Unleash/unleash-server-api-go v0.5.3/go.mod h1:/IvCtBfBrOVOa67elCLig45kt6NYkk79oxmRW80WOFY=
+github.com/Unleash/unleash-server-api-go v0.5.4 h1:sq4TyDxCqAjrn0YJh34wvsEZd7eoQ5F8ErXDwyCoIzI=
+github.com/Unleash/unleash-server-api-go v0.5.4/go.mod h1:/IvCtBfBrOVOa67elCLig45kt6NYkk79oxmRW80WOFY=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/internal/provider/http_helper.go
+++ b/internal/provider/http_helper.go
@@ -8,11 +8,23 @@ import (
 )
 
 func ValidateApiResponse(response *http.Response, code int, diagnostics *diag.Diagnostics, err error) bool {
+	return IsValidApiResponse(response, []int{code}, diagnostics, err)
+}
+
+func IsValidApiResponse(response *http.Response, codes []int, diagnostics *diag.Diagnostics, err error) bool {
 	if response == nil {
 		diagnostics.AddError(
 			"Unable to call api, response is nil",
 			err.Error())
 		return false
+	}
+
+	// this is subtle but I've moved this block up because there are cases
+	// where 409s are a valid response code but the api will still error
+	for _, code := range codes {
+		if response.StatusCode == code {
+			return true
+		}
 	}
 
 	if err != nil {
@@ -22,12 +34,10 @@ func ValidateApiResponse(response *http.Response, code int, diagnostics *diag.Di
 		)
 	}
 
-	if response.StatusCode != code {
-		diagnostics.AddError(
-			fmt.Sprintf("Unexpected HTTP error code received %s", response.Status),
-			fmt.Sprintf("Calling API %s %s\nExpected %v, got %v\n%v", response.Request.Method, response.Request.URL, code, response.StatusCode, response.Body),
-		)
-	}
+	diagnostics.AddError(
+		fmt.Sprintf("Unexpected HTTP error code received %s", response.Status),
+		fmt.Sprintf("Calling API %s %s\nExpected %v, got %v\n%v", response.Request.Method, response.Request.URL, codes, response.StatusCode, response.Body),
+	)
 
-	return !diagnostics.HasError()
+	return false
 }

--- a/internal/provider/project_environment_data_source.go
+++ b/internal/provider/project_environment_data_source.go
@@ -1,0 +1,128 @@
+package provider
+
+import (
+	"context"
+
+	unleash "github.com/Unleash/unleash-server-api-go/client"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &projectEnvironmentDataSource{}
+	_ datasource.DataSourceWithConfigure = &projectEnvironmentDataSource{}
+)
+
+func NewProjectEnvironmentDataSource() datasource.DataSource {
+	return &projectEnvironmentDataSource{}
+}
+
+type projectEnvironmentDataSource struct {
+	client *unleash.APIClient
+}
+
+type projectEnvironmentDataSourceModel struct {
+	ProjectId             types.String `tfsdk:"project_id"`
+	EnvironmentName       types.String `tfsdk:"environment_name"`
+	Enabled               types.Bool   `tfsdk:"enabled"`
+	ChangeRequestsEnabled types.Bool   `tfsdk:"change_requests_enabled"`
+	RequiredApprovals     types.Int64  `tfsdk:"required_approvals"`
+}
+
+func (d *projectEnvironmentDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*unleash.APIClient)
+	if !ok {
+		return
+	}
+	d.client = client
+}
+
+func (d *projectEnvironmentDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_project_environment"
+}
+
+func (d *projectEnvironmentDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "ProjectAccess schema",
+		Attributes: map[string]schema.Attribute{
+			"project_id": schema.StringAttribute{
+				Description: "Project identifier.",
+				Required:    true,
+			},
+			"environment_name": schema.StringAttribute{
+				Description: "Environment identifier, equivalent to the environment name.",
+				Required:    true,
+			},
+			"enabled": schema.BoolAttribute{
+				Description: "If the environment is enabled for this project. This affects whether or not users will be able to enable flags for this environment on this project.",
+				Computed:    true,
+			},
+			"change_requests_enabled": schema.BoolAttribute{
+				Description: "If change requests are required for this environment, the environment must be enabled for this to have effect.",
+				Computed:    true,
+			},
+			"required_approvals": schema.Int64Attribute{
+				Description: "Number of approvals required for change requests.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *projectEnvironmentDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	tflog.Debug(ctx, "Preparing to read project environment change data source")
+
+	var state projectEnvironmentDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	config, getResponse, getErr := d.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(context.Background(), state.ProjectId.ValueString()).Execute()
+
+	if !ValidateApiResponse(getResponse, 200, &resp.Diagnostics, getErr) {
+		return
+	}
+
+	var envChangeRequestConfig *unleash.ChangeRequestEnvironmentConfigSchema
+
+	for _, env := range config {
+		if env.Environment == state.EnvironmentName.ValueString() {
+			envChangeRequestConfig = &env
+			break
+		}
+	}
+
+	if envChangeRequestConfig == nil {
+		state.ChangeRequestsEnabled = types.BoolValue(false)
+		state.RequiredApprovals = types.Int64Null()
+		state.Enabled = types.BoolValue(false)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+		return
+	}
+
+	var requiredApprovals basetypes.Int64Value
+
+	if envChangeRequestConfig.RequiredApprovals.IsSet() && envChangeRequestConfig.RequiredApprovals.Get() != nil {
+		requiredApprovals = types.Int64Value(int64(*envChangeRequestConfig.RequiredApprovals.Get()))
+	} else {
+		requiredApprovals = types.Int64Null()
+	}
+
+	state.ProjectId = types.StringValue(state.ProjectId.ValueString())
+	state.EnvironmentName = types.StringValue(state.EnvironmentName.ValueString())
+	state.ChangeRequestsEnabled = types.BoolValue(envChangeRequestConfig.ChangeRequestEnabled)
+	state.RequiredApprovals = requiredApprovals
+	state.Enabled = types.BoolValue(true)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	tflog.Debug(ctx, "Finished reading project environment change request", map[string]interface{}{"success": true})
+}

--- a/internal/provider/project_environment_data_source_test.go
+++ b/internal/provider/project_environment_data_source_test.go
@@ -1,0 +1,32 @@
+package provider
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccProjectEnvironmentDataSource(t *testing.T) {
+	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
+		t.Skip("Skipping enterprise tests")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "unleash_project_environment" "default_dev" {
+						project_id = "default"
+						environment_name = "development"
+					}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.unleash_project_environment.default_dev", "project_id", "default"),
+					resource.TestCheckResourceAttr("data.unleash_project_environment.default_dev", "change_requests_enabled", "false"),
+					resource.TestCheckNoResourceAttr("data.unleash_project_environment.default_dev", "required_approvals"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/project_environment_resource.go
+++ b/internal/provider/project_environment_resource.go
@@ -1,0 +1,295 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	unleash "github.com/Unleash/unleash-server-api-go/client"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &projectEnvironmentResource{}
+	_ resource.ResourceWithConfigure   = &projectEnvironmentResource{}
+	_ resource.ResourceWithImportState = &projectEnvironmentResource{}
+)
+
+func NewProjectEnvironmentResource() resource.Resource {
+	return &projectEnvironmentResource{}
+}
+
+type projectEnvironmentResource struct {
+	client *unleash.APIClient
+}
+
+type projectEnvironmentResourceModel struct {
+	ProjectId             types.String `tfsdk:"project_id"`
+	EnvironmentName       types.String `tfsdk:"environment_name"`
+	Enabled               types.Bool   `tfsdk:"enabled"`
+	ChangeRequestsEnabled types.Bool   `tfsdk:"change_requests_enabled"`
+	RequiredApprovals     types.Int64  `tfsdk:"required_approvals"`
+}
+
+func (r *projectEnvironmentResource) Configure(ctx context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*unleash.APIClient)
+	if !ok {
+		return
+	}
+	r.client = client
+}
+
+type requiredApprovalsValidator struct{}
+
+func (v requiredApprovalsValidator) Description(_ context.Context) string {
+	return "Ensures required_approvals is between 1 and 10"
+}
+
+func (v requiredApprovalsValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v requiredApprovalsValidator) ValidateInt64(ctx context.Context, req validator.Int64Request, resp *validator.Int64Response) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return // Skip validation for null or unknown values
+	}
+
+	val := req.ConfigValue.ValueInt64()
+
+	if val < 1 || val > 10 {
+		resp.Diagnostics.AddError(
+			"Invalid required_approvals value",
+			fmt.Sprintf("The required_approvals attribute must be between 1 and 10, but got: %d", val),
+		)
+	}
+}
+
+func (r *projectEnvironmentResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_project_change_request"
+}
+
+func (r *projectEnvironmentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "ProjectAccess schema",
+		Attributes: map[string]schema.Attribute{
+			"project_id": schema.StringAttribute{
+				Description: "Project identifier.",
+				Required:    true,
+			},
+			"environment_name": schema.StringAttribute{
+				Description: "Environment identifier, equivalen	t to the environment name.",
+				Required:    true,
+			},
+			"enabled": schema.BoolAttribute{
+				Description: "If the environment is enabled for this project. This affects whether or not users will be able to enable flags for this environment on this project.",
+				Required:    true,
+			},
+			"change_requests_enabled": schema.BoolAttribute{
+				Description: "If change requests are required for this environment, the environment must be enabled for this to have effect.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"required_approvals": schema.Int64Attribute{
+				Description: "Number of approvals required for change requests.",
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.Int64{
+					requiredApprovalsValidator{},
+				},
+			},
+		},
+	}
+}
+
+func (r *projectEnvironmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("projectId"), req, resp)
+
+	resource.ImportStatePassthroughID(ctx, path.Root("environmentId"), req, resp)
+}
+
+func (r *projectEnvironmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	tflog.Debug(ctx, "Setting project environment config")
+
+	var plan projectEnvironmentResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !r.configureProjectEnvironment(ctx, plan, &resp.Diagnostics) {
+		return
+	}
+
+	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(context.Background(), plan.ProjectId.ValueString()).Execute()
+
+	if !ValidateApiResponse(getResponse, 200, &resp.Diagnostics, getErr) {
+		return
+	}
+
+	plan.hydrateResponseFromApi(config)
+
+	resp.State.Set(ctx, plan)
+
+	tflog.Debug(ctx, "Finished setting project environment", map[string]interface{}{"success": true})
+}
+
+func (r *projectEnvironmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	tflog.Debug(ctx, "Preparing to read project environment change request")
+
+	var state projectEnvironmentResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(context.Background(), state.ProjectId.ValueString()).Execute()
+
+	if !ValidateApiResponse(getResponse, 200, &resp.Diagnostics, getErr) {
+		return
+	}
+
+	state.hydrateResponseFromApi(config)
+
+	resp.State.Set(ctx, state)
+
+	tflog.Debug(ctx, "Finished reading project environment change request", map[string]interface{}{"success": true})
+}
+
+func (r *projectEnvironmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	tflog.Debug(ctx, "Preparing to update project environment change request")
+
+	var plan projectEnvironmentResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !r.configureProjectEnvironment(ctx, plan, &resp.Diagnostics) {
+		return
+	}
+
+	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(context.Background(), plan.ProjectId.ValueString()).Execute()
+
+	if !ValidateApiResponse(getResponse, 200, &resp.Diagnostics, getErr) {
+		return
+	}
+
+	plan.hydrateResponseFromApi(config)
+
+	resp.State.Set(ctx, plan)
+
+	tflog.Debug(ctx, "Finished updating project environment change request", map[string]interface{}{"success": true})
+}
+
+func (r *projectEnvironmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	tflog.Debug(ctx, "Preparing to delete project environment change request, this will unlink change requests from the relevant project")
+
+	var state projectEnvironmentResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	disableChangeRequest := *unleash.NewUpdateChangeRequestEnvironmentConfigSchemaWithDefaults()
+	disableChangeRequest.ChangeRequestsEnabled = false
+	disableChangeRequest.SetRequiredApprovals(0)
+
+	updateResponse, updateErr := r.client.ChangeRequestsAPI.UpdateProjectChangeRequestConfig(ctx, state.ProjectId.ValueString(), state.EnvironmentName.ValueString()).UpdateChangeRequestEnvironmentConfigSchema(disableChangeRequest).Execute()
+
+	if !ValidateApiResponse(updateResponse, 204, &resp.Diagnostics, updateErr) {
+		return
+	}
+
+	deleteResponse, err := r.client.ProjectsAPI.RemoveEnvironmentFromProject(ctx, state.ProjectId.ValueString(), state.EnvironmentName.ValueString()).Execute()
+
+	if !ValidateApiResponse(deleteResponse, 200, &resp.Diagnostics, err) {
+		return
+	}
+
+	resp.State.RemoveResource(ctx)
+
+	tflog.Debug(ctx, "Finished deleting project environment change request", map[string]interface{}{"success": true})
+}
+
+func (r *projectEnvironmentResource) configureProjectEnvironment(ctx context.Context, plan projectEnvironmentResourceModel, diagnostics *diag.Diagnostics) bool {
+	if plan.Enabled.ValueBool() {
+		enabledEnvironmentRequest := *unleash.NewProjectEnvironmentSchemaWithDefaults()
+		enabledEnvironmentRequest.Environment = plan.EnvironmentName.ValueString()
+
+		httpResponse, err := r.client.ProjectsAPI.AddEnvironmentToProject(ctx, plan.ProjectId.ValueString()).
+			ProjectEnvironmentSchema(enabledEnvironmentRequest).
+			Execute()
+
+		if !IsValidApiResponse(httpResponse, []int{200, 409}, diagnostics, err) {
+			return false
+		}
+
+		enableChangeRequest := *unleash.NewUpdateChangeRequestEnvironmentConfigSchemaWithDefaults()
+		enableChangeRequest.SetChangeRequestsEnabled(plan.ChangeRequestsEnabled.ValueBool())
+		if !plan.RequiredApprovals.IsNull() && plan.RequiredApprovals.ValueInt64Pointer() != nil {
+			enableChangeRequest.SetRequiredApprovals(int32(*plan.RequiredApprovals.ValueInt64Pointer()))
+		}
+
+		updateResponse, updateErr := r.client.ChangeRequestsAPI.UpdateProjectChangeRequestConfig(ctx, plan.ProjectId.ValueString(), plan.EnvironmentName.ValueString()).
+			UpdateChangeRequestEnvironmentConfigSchema(enableChangeRequest).
+			Execute()
+
+		if !IsValidApiResponse(updateResponse, []int{204, 409}, diagnostics, updateErr) {
+			return false
+		}
+	} else {
+		httpResponse, err := r.client.ProjectsAPI.RemoveEnvironmentFromProject(ctx, plan.ProjectId.ValueString(), plan.EnvironmentName.ValueString()).Execute()
+
+		if !ValidateApiResponse(httpResponse, 200, diagnostics, err) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *projectEnvironmentResourceModel) hydrateResponseFromApi(config []unleash.ChangeRequestEnvironmentConfigSchema) {
+	var envChangeRequestConfig *unleash.ChangeRequestEnvironmentConfigSchema
+
+	for _, env := range config {
+		if env.Environment == m.EnvironmentName.ValueString() {
+			envChangeRequestConfig = &env
+			break
+		}
+	}
+
+	if envChangeRequestConfig == nil {
+		m.ChangeRequestsEnabled = types.BoolValue(false)
+		m.RequiredApprovals = types.Int64Null()
+		m.Enabled = types.BoolValue(false)
+		return
+	}
+
+	var requiredApprovals basetypes.Int64Value
+
+	if envChangeRequestConfig.RequiredApprovals.IsSet() && envChangeRequestConfig.RequiredApprovals.Get() != nil {
+		requiredApprovals = types.Int64Value(int64(*envChangeRequestConfig.RequiredApprovals.Get()))
+	} else {
+		requiredApprovals = types.Int64Null()
+	}
+
+	m.ProjectId = types.StringValue(m.ProjectId.ValueString())
+	m.EnvironmentName = types.StringValue(m.EnvironmentName.ValueString())
+	m.ChangeRequestsEnabled = types.BoolValue(envChangeRequestConfig.ChangeRequestEnabled)
+	m.RequiredApprovals = requiredApprovals
+	m.Enabled = types.BoolValue(true)
+}

--- a/internal/provider/project_environment_resource.go
+++ b/internal/provider/project_environment_resource.go
@@ -75,7 +75,7 @@ func (v requiredApprovalsValidator) ValidateInt64(ctx context.Context, req valid
 }
 
 func (r *projectEnvironmentResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_project_change_request"
+	resp.TypeName = req.ProviderTypeName + "_project_environment"
 }
 
 func (r *projectEnvironmentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/provider/project_environment_resource.go
+++ b/internal/provider/project_environment_resource.go
@@ -61,7 +61,7 @@ func (v requiredApprovalsValidator) MarkdownDescription(ctx context.Context) str
 
 func (v requiredApprovalsValidator) ValidateInt64(ctx context.Context, req validator.Int64Request, resp *validator.Int64Response) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
-		return // Skip validation for null or unknown values
+		return
 	}
 
 	val := req.ConfigValue.ValueInt64()

--- a/internal/provider/project_environment_resource_test.go
+++ b/internal/provider/project_environment_resource_test.go
@@ -1,0 +1,165 @@
+package provider
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccProjectChangeRequestResource(t *testing.T) {
+	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
+		t.Skip("Skipping enterprise tests")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "unleash_project" "galaxy-wide-energy" {
+						id = "dysonsphere"
+						name = "dysonsphere"
+					}
+
+					resource "unleash_environment" "space" {
+						name = "outerspace"
+						type = "vacuum"
+					}
+
+					resource "unleash_project_change_request" "approvals" {
+						project_id = unleash_project.galaxy-wide-energy.id
+						environment_name = unleash_environment.space.name
+						enabled = true
+						change_requests_enabled = true
+						required_approvals = 2
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "enabled", "true"),
+					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "change_requests_enabled", "true"),
+					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "required_approvals", "2"),
+				),
+			},
+			{
+				Config: `
+					resource "unleash_project" "galaxy-wide-energy" {
+						id = "dysonsphere"
+						name = "dysonsphere"
+					}
+
+					resource "unleash_environment" "space" {
+						name = "outerspace"
+						type = "vacuum"
+					}
+
+					resource "unleash_project_change_request" "approvals" {
+						project_id = unleash_project.galaxy-wide-energy.id
+						environment_name = unleash_environment.space.name
+						enabled = true
+						change_requests_enabled = true
+						required_approvals = 20
+					}
+				`,
+				ExpectError: regexp.MustCompile(`(?s)Error: Invalid required_approvals value.*The required_approvals attribute must be between 1 and 10, but got: 20`),
+			},
+			{
+				Config: `
+					resource "unleash_project" "galaxy-wide-energy" {
+						id = "dysonsphere"
+						name = "dysonsphere"
+					}
+
+					resource "unleash_environment" "space" {
+						name = "outerspace"
+						type = "vacuum"
+					}
+
+					resource "unleash_project_change_request" "approvals" {
+						project_id = unleash_project.galaxy-wide-energy.id
+						environment_name = unleash_environment.space.name
+						enabled = true
+						change_requests_enabled = true
+						required_approvals = 0
+					}
+				`,
+				ExpectError: regexp.MustCompile(`(?s)Error: Invalid required_approvals value.*The required_approvals attribute must be between 1 and 10, but got: 0`),
+			},
+			{
+				Config: `
+					resource "unleash_project" "galaxy-wide-energy" {
+						id = "dysonsphere"
+						name = "dysonsphere"
+					}
+
+					resource "unleash_environment" "space" {
+						name = "outerspace"
+						type = "vacuum"
+					}
+
+					resource "unleash_project_change_request" "approvals" {
+						project_id = unleash_project.galaxy-wide-energy.id
+						environment_name = unleash_environment.space.name
+						enabled = true
+						change_requests_enabled = false
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "enabled", "true"),
+					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "change_requests_enabled", "false"),
+					resource.TestCheckNoResourceAttr("unleash_project_change_request.approvals", "required_approvals"),
+				),
+			},
+			{
+				Config: `
+					resource "unleash_project" "galaxy-wide-energy" {
+						id = "dysonsphere"
+						name = "dysonsphere"
+					}
+
+					resource "unleash_environment" "space" {
+						name = "outerspace"
+						type = "vacuum"
+					}
+
+					resource "unleash_project_change_request" "approvals" {
+						project_id = unleash_project.galaxy-wide-energy.id
+						environment_name = unleash_environment.space.name
+						enabled = false
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "enabled", "false"),
+					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "change_requests_enabled", "false"),
+				),
+			},
+			{
+				Config: `
+					resource "unleash_project" "galaxy-wide-energy" {
+						id = "dysonsphere"
+						name = "dysonsphere"
+					}
+
+					resource "unleash_environment" "testing" {
+						name = "lab-environment"
+						type = "testing-environment"
+					}
+
+					resource "unleash_project_change_request" "approvals" {
+						project_id = unleash_project.galaxy-wide-energy.id
+						environment_name = unleash_environment.testing.name
+						enabled = true
+						change_requests_enabled = true
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "enabled", "true"),
+					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "change_requests_enabled", "true"),
+					// Fresh creation should clamp this value to 1
+					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "required_approvals", "1"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/project_environment_resource_test.go
+++ b/internal/provider/project_environment_resource_test.go
@@ -28,7 +28,7 @@ func TestAccProjectChangeRequestResource(t *testing.T) {
 						type = "vacuum"
 					}
 
-					resource "unleash_project_change_request" "approvals" {
+					resource "unleash_project_environment" "approvals" {
 						project_id = unleash_project.galaxy-wide-energy.id
 						environment_name = unleash_environment.space.name
 						enabled = true
@@ -37,9 +37,9 @@ func TestAccProjectChangeRequestResource(t *testing.T) {
 					}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "enabled", "true"),
-					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "change_requests_enabled", "true"),
-					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "required_approvals", "2"),
+					resource.TestCheckResourceAttr("unleash_project_environment.approvals", "enabled", "true"),
+					resource.TestCheckResourceAttr("unleash_project_environment.approvals", "change_requests_enabled", "true"),
+					resource.TestCheckResourceAttr("unleash_project_environment.approvals", "required_approvals", "2"),
 				),
 			},
 			{
@@ -54,7 +54,7 @@ func TestAccProjectChangeRequestResource(t *testing.T) {
 						type = "vacuum"
 					}
 
-					resource "unleash_project_change_request" "approvals" {
+					resource "unleash_project_environment" "approvals" {
 						project_id = unleash_project.galaxy-wide-energy.id
 						environment_name = unleash_environment.space.name
 						enabled = true
@@ -76,7 +76,7 @@ func TestAccProjectChangeRequestResource(t *testing.T) {
 						type = "vacuum"
 					}
 
-					resource "unleash_project_change_request" "approvals" {
+					resource "unleash_project_environment" "approvals" {
 						project_id = unleash_project.galaxy-wide-energy.id
 						environment_name = unleash_environment.space.name
 						enabled = true
@@ -98,7 +98,7 @@ func TestAccProjectChangeRequestResource(t *testing.T) {
 						type = "vacuum"
 					}
 
-					resource "unleash_project_change_request" "approvals" {
+					resource "unleash_project_environment" "approvals" {
 						project_id = unleash_project.galaxy-wide-energy.id
 						environment_name = unleash_environment.space.name
 						enabled = true
@@ -106,9 +106,9 @@ func TestAccProjectChangeRequestResource(t *testing.T) {
 					}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "enabled", "true"),
-					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "change_requests_enabled", "false"),
-					resource.TestCheckNoResourceAttr("unleash_project_change_request.approvals", "required_approvals"),
+					resource.TestCheckResourceAttr("unleash_project_environment.approvals", "enabled", "true"),
+					resource.TestCheckResourceAttr("unleash_project_environment.approvals", "change_requests_enabled", "false"),
+					resource.TestCheckNoResourceAttr("unleash_project_environment.approvals", "required_approvals"),
 				),
 			},
 			{
@@ -123,15 +123,15 @@ func TestAccProjectChangeRequestResource(t *testing.T) {
 						type = "vacuum"
 					}
 
-					resource "unleash_project_change_request" "approvals" {
+					resource "unleash_project_environment" "approvals" {
 						project_id = unleash_project.galaxy-wide-energy.id
 						environment_name = unleash_environment.space.name
 						enabled = false
 					}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "enabled", "false"),
-					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "change_requests_enabled", "false"),
+					resource.TestCheckResourceAttr("unleash_project_environment.approvals", "enabled", "false"),
+					resource.TestCheckResourceAttr("unleash_project_environment.approvals", "change_requests_enabled", "false"),
 				),
 			},
 			{
@@ -146,7 +146,7 @@ func TestAccProjectChangeRequestResource(t *testing.T) {
 						type = "testing-environment"
 					}
 
-					resource "unleash_project_change_request" "approvals" {
+					resource "unleash_project_environment" "approvals" {
 						project_id = unleash_project.galaxy-wide-energy.id
 						environment_name = unleash_environment.testing.name
 						enabled = true
@@ -154,10 +154,10 @@ func TestAccProjectChangeRequestResource(t *testing.T) {
 					}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "enabled", "true"),
-					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "change_requests_enabled", "true"),
+					resource.TestCheckResourceAttr("unleash_project_environment.approvals", "enabled", "true"),
+					resource.TestCheckResourceAttr("unleash_project_environment.approvals", "change_requests_enabled", "true"),
 					// Fresh creation should clamp this value to 1
-					resource.TestCheckResourceAttr("unleash_project_change_request.approvals", "required_approvals", "1"),
+					resource.TestCheckResourceAttr("unleash_project_environment.approvals", "required_approvals", "1"),
 				),
 			},
 		},

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -102,6 +102,7 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 	createProjectRequest := *unleash.NewCreateProjectSchemaWithDefaults()
 	createProjectRequest.Name = *plan.Name.ValueStringPointer()
 	createProjectRequest.Id = plan.Id.ValueStringPointer()
+	createProjectRequest.Environments = []string{}
 	if !plan.Description.IsNull() {
 		createProjectRequest.Description = *unleash.NewNullableString(plan.Description.ValueStringPointer())
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -176,6 +176,7 @@ func (p *UnleashProvider) Resources(ctx context.Context) []func() resource.Resou
 		NewSamlResource,
 		NewContextFieldResource,
 		NewEnvironmentResource,
+		NewProjectEnvironmentResource,
 	}
 }
 
@@ -187,6 +188,7 @@ func (p *UnleashProvider) DataSources(ctx context.Context) []func() datasource.D
 		NewRoleDataSource,
 		NewContextFieldDataSource,
 		NewEnvironmentDataSource,
+		NewProjectEnvironmentDataSource,
 	}
 }
 


### PR DESCRIPTION
Adds a project environment data source and resource. This manages environment enablement and change request config for a project/environment. Turns out enablement is very closely tied to change requests so I've put them into the same resource (change requests config silently fails without enablement). 