### PR TITLE
feat: update tests to match v7 expectations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
           - "1.3.*"
           - "1.4.*"
         docker-image:
-          - "726824350591.dkr.ecr.eu-central-1.amazonaws.com/unleash-enterprise:latest"
+          - "unleashorg/unleash-enterprise:latest"
           - "unleashorg/unleash-server:latest"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -81,19 +81,11 @@ jobs:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
       - run: go mod download
-      - name: Start Unleash enterprise test instance
-        if: contains(matrix.docker-image, 'unleash-enterprise')
-        run: |
-          curl https://app.unleash-hosted.com/docker-login/token/${{ secrets.ECR_ENTERPRISE_TOKEN }} | docker login --username AWS --password-stdin 726824350591.dkr.ecr.eu-central-1.amazonaws.com
-          docker compose up -d --wait -t 90
-        env:
-          UNLEASH_DOCKER_IMAGE: ${{ matrix.docker-image }}
-          UNLEASH_DEV_LICENSE: ${{ secrets.UNLEASH_DEV_LICENSE }}
-      - name: Start Unleash OSS test instance
-        if: contains(matrix.docker-image, 'unleash-server')
+      - name: Start ${{ matrix.docker-image }} instance
         run: docker compose up -d --wait -t 90
         env:
           UNLEASH_DOCKER_IMAGE: ${{ matrix.docker-image }}
+          UNLEASH_DEV_LICENSE: ${{ secrets.UNLEASH_DEV_LICENSE }}
       - run: go test -v -cover ./internal/provider/
         env:
           TF_ACC: "1"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ go install
 
 https://developer.hashicorp.com/terraform/plugin/testing
 
-**Note**: some tests rely on an enterprise version of Unleash. To run those tests locally you need to set the environment variable `UNLEASH_ENTERPRISE=true`. To run docker with an enterprise image, login to GH docker registry following [preparation steps](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic) and then set the environment variable `UNLEASH_DOCKER_IMAGE` pointing to the enterprise docker image.
+**Note**: some tests rely on an enterprise version of Unleash. To run those tests locally you need to set the environment variable `UNLEASH_ENTERPRISE=true`. To run docker with an enterprise image: `UNLEASH_DOCKER_IMAGE=unleashorg/unleash-enterprise:latest docker compose up` (you will also need a valid license key that you can provide at startup with `UNLEASH_DEV_LICENSE=<your license key>`).
 
 Run tests (most likely we will not have a lot of unit tests but instead we'll have acceptance tests)
 

--- a/internal/provider/api_token_resource.go
+++ b/internal/provider/api_token_resource.go
@@ -37,8 +37,8 @@ type apiTokenResourceModel struct {
 	Type types.String `tfsdk:"type"`
 	// The environment the token has access to. `*` if it has access to all environments.
 	Environment types.String `tfsdk:"environment"`
-	// The project this token belongs to.
-	Project types.String `tfsdk:"project"`
+	// The project this token belongs to. Deprecated: use Projects instead.
+	Project types.String `tfsdk:"project" deprecated:"true"`
 	// The list of projects this token has access to. If the token has access to specific projects they will be listed here. If the token has access to all projects it will be represented as `[*]`
 	Projects types.Set `tfsdk:"projects"`
 	// The token's expiration date. NULL if the token doesn't have an expiration set.

--- a/internal/provider/api_token_resource_test.go
+++ b/internal/provider/api_token_resource_test.go
@@ -25,7 +25,6 @@ func TestAccApiTokenResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("unleash_api_token.frontend_token", "expires_at"),
 					resource.TestCheckResourceAttr("unleash_api_token.frontend_token", "token_name", "frontend_token"),
 					resource.TestCheckResourceAttr("unleash_api_token.frontend_token", "environment", "development"),
-					resource.TestCheckResourceAttr("unleash_api_token.frontend_token", "project", "*"),
 					resource.TestCheckResourceAttr("unleash_api_token.frontend_token", "projects.0", "*"),
 				),
 			},
@@ -35,7 +34,7 @@ func TestAccApiTokenResource(t *testing.T) {
 					token_name = "client_token"
 					type = "client"
 					expires_at = "2024-12-31T23:59:59Z"
-					project = "default"
+					projects = ["default"]
 					environment = "development"
 				}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -43,7 +42,6 @@ func TestAccApiTokenResource(t *testing.T) {
 					resource.TestCheckResourceAttr("unleash_api_token.client_token", "expires_at", "2024-12-31T23:59:59Z"),
 					resource.TestCheckResourceAttr("unleash_api_token.client_token", "token_name", "client_token"),
 					resource.TestCheckResourceAttr("unleash_api_token.client_token", "environment", "development"),
-					resource.TestCheckResourceAttr("unleash_api_token.client_token", "project", "default"),
 					resource.TestCheckResourceAttr("unleash_api_token.client_token", "projects.0", "default"),
 				),
 			},
@@ -53,7 +51,7 @@ func TestAccApiTokenResource(t *testing.T) {
 					token_name = "client_token"
 					type = "client"
 					expires_at = "2025-01-01T12:00:00Z"
-					project = "default"
+					projects = ["default"]
 					environment = "development"
 				}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -61,7 +59,6 @@ func TestAccApiTokenResource(t *testing.T) {
 					resource.TestCheckResourceAttr("unleash_api_token.client_token", "expires_at", "2025-01-01T12:00:00Z"),
 					resource.TestCheckResourceAttr("unleash_api_token.client_token", "token_name", "client_token"),
 					resource.TestCheckResourceAttr("unleash_api_token.client_token", "environment", "development"),
-					resource.TestCheckResourceAttr("unleash_api_token.client_token", "project", "default"),
 					resource.TestCheckResourceAttr("unleash_api_token.client_token", "projects.0", "default"),
 				),
 			},
@@ -76,8 +73,7 @@ func TestAccApiTokenResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("unleash_api_token.client_no_expire", "secret"),
 					resource.TestCheckNoResourceAttr("unleash_api_token.client_no_expire", "expires_at"),
 					resource.TestCheckResourceAttr("unleash_api_token.client_no_expire", "token_name", "client_no_expire"),
-					resource.TestCheckResourceAttr("unleash_api_token.client_no_expire", "environment", "default"),
-					resource.TestCheckResourceAttr("unleash_api_token.client_no_expire", "project", "default"),
+					resource.TestCheckResourceAttr("unleash_api_token.client_no_expire", "environment", "development"),
 					resource.TestCheckResourceAttr("unleash_api_token.client_no_expire", "projects.0", "default"),
 				),
 			},


### PR DESCRIPTION
## About the changes
[Unleash v7](https://github.com/Unleash/unleash/releases/tag/v7.0.0) dropped the default environment for good. Also, in the API tokens response the field `project`  got dropped in favor of `projects`. The input also dropped `project` in favor of `projects`.