### PR TITLE
fix: context management

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ TF_LOG=debug TF_ACC=1 go test ./... -v -count=1
 ```
 
 To run enterprise tests (you have to make sure you're running an enterprise server)
+
 ```shell
 UNLEASH_ENTERPRISE=true TF_LOG=debug TF_ACC=1 go test ./... -v -count=1
 ```
@@ -61,7 +62,7 @@ make testacc
 
 ### Before pushing
 
-- `golangci-lint run --fix` to lint the code
+- `golangci-lint run --fix` to lint the code (You can install it with `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`)
 - `go generate ./...` to update docs
 
 ## Using the provider

--- a/internal/provider/context_field_resource.go
+++ b/internal/provider/context_field_resource.go
@@ -119,13 +119,13 @@ func (r *contextFieldResource) Create(ctx context.Context, req resource.CreateRe
 	createContextFieldRequest := *unleash.NewCreateContextFieldSchemaWithDefaults()
 	createContextFieldRequest.Name = *plan.Name.ValueStringPointer()
 
-	var contextErr = populateContextField(&createContextFieldRequest, plan)
+	var contextErr = populateContextField(ctx, &createContextFieldRequest, plan)
 	if contextErr != nil {
 		resp.Diagnostics.AddError("error populating context field", contextErr.Error())
 		return
 	}
 
-	var contextField, httpRes, err = r.client.ContextAPI.CreateContextField(context.Background()).CreateContextFieldSchema(createContextFieldRequest).Execute()
+	var contextField, httpRes, err = r.client.ContextAPI.CreateContextField(ctx).CreateContextFieldSchema(createContextFieldRequest).Execute()
 	if !ValidateApiResponse(httpRes, 201, &resp.Diagnostics, err) {
 		return
 	}
@@ -145,7 +145,7 @@ func (r *contextFieldResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	contextField, httpRes, err := r.client.ContextAPI.GetContextField(context.Background(), state.Name.ValueString()).Execute()
+	contextField, httpRes, err := r.client.ContextAPI.GetContextField(ctx, state.Name.ValueString()).Execute()
 	if !ValidateApiResponse(httpRes, 200, &resp.Diagnostics, err) {
 		return
 	}
@@ -166,18 +166,18 @@ func (r *contextFieldResource) Update(ctx context.Context, req resource.UpdateRe
 
 	updateContextFieldRequest := *unleash.NewUpdateContextFieldSchemaWithDefaults()
 
-	var contextErr = populateContextField(&updateContextFieldRequest, plan)
+	var contextErr = populateContextField(ctx, &updateContextFieldRequest, plan)
 	if contextErr != nil {
 		resp.Diagnostics.AddError("error populating context field", contextErr.Error())
 		return
 	}
 
-	var httpRes, err = r.client.ContextAPI.UpdateContextField(context.Background(), plan.Name.ValueString()).UpdateContextFieldSchema(updateContextFieldRequest).Execute()
+	var httpRes, err = r.client.ContextAPI.UpdateContextField(ctx, plan.Name.ValueString()).UpdateContextFieldSchema(updateContextFieldRequest).Execute()
 	if !ValidateApiResponse(httpRes, 200, &resp.Diagnostics, err) {
 		return
 	}
 
-	contextField, httpRes, err := r.client.ContextAPI.GetContextField(context.Background(), plan.Name.ValueString()).Execute()
+	contextField, httpRes, err := r.client.ContextAPI.GetContextField(ctx, plan.Name.ValueString()).Execute()
 	if !ValidateApiResponse(httpRes, 200, &resp.Diagnostics, err) {
 		return
 	}
@@ -197,7 +197,7 @@ func (r *contextFieldResource) Delete(ctx context.Context, req resource.DeleteRe
 		return
 	}
 
-	httpRes, err := r.client.ContextAPI.DeleteContextField(context.Background(), state.Name.ValueString()).Execute()
+	httpRes, err := r.client.ContextAPI.DeleteContextField(ctx, state.Name.ValueString()).Execute()
 	if !ValidateApiResponse(httpRes, 200, &resp.Diagnostics, err) {
 		return
 	}
@@ -265,7 +265,7 @@ func (m *contextFieldResourceModel) hydrateFromApi(api unleash.ContextFieldSchem
 	)
 }
 
-func populateContextField(request ContextFieldSetter, plan contextFieldResourceModel) error {
+func populateContextField(ctx context.Context, request ContextFieldSetter, plan contextFieldResourceModel) error {
 	if !plan.Description.IsNull() {
 		request.SetDescription(*plan.Description.ValueStringPointer())
 	}
@@ -277,7 +277,7 @@ func populateContextField(request ContextFieldSetter, plan contextFieldResourceM
 	}
 
 	if !plan.LegalValues.IsNull() && !plan.LegalValues.IsUnknown() {
-		legalValuesList, diags := plan.LegalValues.ToListValue(context.Background())
+		legalValuesList, diags := plan.LegalValues.ToListValue(ctx)
 		if diags.HasError() {
 			return fmt.Errorf("error extracting legal values: %s", diags)
 		}

--- a/internal/provider/oidc_resource.go
+++ b/internal/provider/oidc_resource.go
@@ -96,7 +96,7 @@ func (r *oidcResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	tflog.Debug(ctx, "Preparing to read OIDC configuration")
 	var plan oidcResourceModel
 
-	oidcSettings, httpRes, err := r.client.AuthAPI.GetOidcSettings(context.Background()).Execute()
+	oidcSettings, httpRes, err := r.client.AuthAPI.GetOidcSettings(ctx).Execute()
 
 	if !ValidateApiResponse(httpRes, 200, &resp.Diagnostics, err) {
 		return
@@ -123,7 +123,7 @@ func (r *oidcResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	oidcSettingsResponse, err := updateOidcConfig(plan, r.client, &resp.Diagnostics)
+	oidcSettingsResponse, err := updateOidcConfig(ctx, plan, r.client, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update OIDC configuration", err.Error())
 		return
@@ -149,7 +149,7 @@ func (r *oidcResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	oidcSettingsResponse, err := updateOidcConfig(plan, r.client, &resp.Diagnostics)
+	oidcSettingsResponse, err := updateOidcConfig(ctx, plan, r.client, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update OIDC configuration", err.Error())
 		return
@@ -185,7 +185,7 @@ func (r *oidcResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		OidcSettingsSchemaOneOf: innerSettings,
 	}
 
-	_, httpRes, err := r.client.AuthAPI.SetOidcSettings(context.Background()).OidcSettingsSchema(oidcSettings).Execute()
+	_, httpRes, err := r.client.AuthAPI.SetOidcSettings(ctx).OidcSettingsSchema(oidcSettings).Execute()
 
 	if !ValidateApiResponse(httpRes, 200, &resp.Diagnostics, err) {
 		return
@@ -197,9 +197,9 @@ func (r *oidcResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	tflog.Debug(ctx, "OIDC configuration cleared")
 }
 
-func updateOidcConfig(plan oidcResourceModel, apiClient *client.APIClient, diagnostics *diag.Diagnostics) (*client.OidcSettingsResponseSchema, error) {
+func updateOidcConfig(ctx context.Context, plan oidcResourceModel, apiClient *client.APIClient, diagnostics *diag.Diagnostics) (*client.OidcSettingsResponseSchema, error) {
 
-	preOidcSettings, preHttpRes, preErr := apiClient.AuthAPI.GetOidcSettings(context.Background()).Execute()
+	preOidcSettings, preHttpRes, preErr := apiClient.AuthAPI.GetOidcSettings(ctx).Execute()
 
 	if !ValidateApiResponse(preHttpRes, 200, diagnostics, preErr) {
 		return nil, preErr
@@ -243,14 +243,14 @@ func updateOidcConfig(plan oidcResourceModel, apiClient *client.APIClient, diagn
 		OidcSettingsSchemaOneOf: innerSettings,
 	}
 
-	_, httpRes, err := apiClient.AuthAPI.SetOidcSettings(context.Background()).OidcSettingsSchema(oidcSettings).Execute()
+	_, httpRes, err := apiClient.AuthAPI.SetOidcSettings(ctx).OidcSettingsSchema(oidcSettings).Execute()
 
 	if !ValidateApiResponse(httpRes, 200, diagnostics, err) {
 		return nil, err
 	}
 
 	// the post request does not return everything, so we need to do another get to get the full object
-	oidcSettingsResponse, httpRes, err := apiClient.AuthAPI.GetOidcSettings(context.Background()).Execute()
+	oidcSettingsResponse, httpRes, err := apiClient.AuthAPI.GetOidcSettings(ctx).Execute()
 
 	if !ValidateApiResponse(httpRes, 200, diagnostics, err) {
 		return nil, err

--- a/internal/provider/project_environment_data_source.go
+++ b/internal/provider/project_environment_data_source.go
@@ -86,7 +86,7 @@ func (d *projectEnvironmentDataSource) Read(ctx context.Context, req datasource.
 		return
 	}
 
-	config, getResponse, getErr := d.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(context.Background(), state.ProjectId.ValueString()).Execute()
+	config, getResponse, getErr := d.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, state.ProjectId.ValueString()).Execute()
 
 	if !ValidateApiResponse(getResponse, 200, &resp.Diagnostics, getErr) {
 		return

--- a/internal/provider/project_environment_resource.go
+++ b/internal/provider/project_environment_resource.go
@@ -132,7 +132,7 @@ func (r *projectEnvironmentResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(context.Background(), plan.ProjectId.ValueString()).Execute()
+	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, plan.ProjectId.ValueString()).Execute()
 
 	if !ValidateApiResponse(getResponse, 200, &resp.Diagnostics, getErr) {
 		return
@@ -155,7 +155,7 @@ func (r *projectEnvironmentResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(context.Background(), state.ProjectId.ValueString()).Execute()
+	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, state.ProjectId.ValueString()).Execute()
 
 	if !ValidateApiResponse(getResponse, 200, &resp.Diagnostics, getErr) {
 		return
@@ -182,7 +182,7 @@ func (r *projectEnvironmentResource) Update(ctx context.Context, req resource.Up
 		return
 	}
 
-	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(context.Background(), plan.ProjectId.ValueString()).Execute()
+	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, plan.ProjectId.ValueString()).Execute()
 
 	if !ValidateApiResponse(getResponse, 200, &resp.Diagnostics, getErr) {
 		return

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -122,7 +122,7 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 	updateProjectSettingsRequest := *unleash.NewUpdateProjectEnterpriseSettingsSchemaWithDefaults()
 	updateProjectSettingsRequest.SetMode(mode)
 
-	updateSettingsResponse, err := r.client.ProjectsAPI.UpdateProjectEnterpriseSettings(context.Background(), *plan.Id.ValueStringPointer()).UpdateProjectEnterpriseSettingsSchema(updateProjectSettingsRequest).Execute()
+	updateSettingsResponse, err := r.client.ProjectsAPI.UpdateProjectEnterpriseSettings(ctx, *plan.Id.ValueStringPointer()).UpdateProjectEnterpriseSettingsSchema(updateProjectSettingsRequest).Execute()
 
 	if !ValidateApiResponse(updateSettingsResponse, 200, &resp.Diagnostics, err) {
 		return
@@ -209,7 +209,7 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 	updateProjectSettingsRequest := *unleash.NewUpdateProjectEnterpriseSettingsSchemaWithDefaults()
 	updateProjectSettingsRequest.SetMode(mode)
 
-	updateSettingsResponse, err := r.client.ProjectsAPI.UpdateProjectEnterpriseSettings(context.Background(), *state.Id.ValueStringPointer()).UpdateProjectEnterpriseSettingsSchema(updateProjectSettingsRequest).Execute()
+	updateSettingsResponse, err := r.client.ProjectsAPI.UpdateProjectEnterpriseSettings(ctx, *state.Id.ValueStringPointer()).UpdateProjectEnterpriseSettingsSchema(updateProjectSettingsRequest).Execute()
 
 	if !ValidateApiResponse(updateSettingsResponse, 200, &resp.Diagnostics, err) {
 		return

--- a/internal/provider/saml_resource.go
+++ b/internal/provider/saml_resource.go
@@ -96,7 +96,7 @@ func (r *samlResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	tflog.Debug(ctx, "Preparing to read SAML configuration")
 	var plan samlResourceModel
 
-	samlSettings, httpRes, err := r.client.AuthAPI.GetSamlSettings(context.Background()).Execute()
+	samlSettings, httpRes, err := r.client.AuthAPI.GetSamlSettings(ctx).Execute()
 
 	if !ValidateApiResponse(httpRes, 200, &resp.Diagnostics, err) {
 		return
@@ -122,7 +122,7 @@ func (r *samlResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	samlSettingsResponse, err := updateSamlConfig(plan, r.client, &resp.Diagnostics)
+	samlSettingsResponse, err := updateSamlConfig(ctx, plan, r.client, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create SAML configuration", err.Error())
 		return
@@ -148,7 +148,7 @@ func (r *samlResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	samlSettingsResponse, err := updateSamlConfig(plan, r.client, &resp.Diagnostics)
+	samlSettingsResponse, err := updateSamlConfig(ctx, plan, r.client, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update SAML configuration", err.Error())
 		return
@@ -168,8 +168,8 @@ func (r *samlResource) Update(ctx context.Context, req resource.UpdateRequest, r
 func (r *samlResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 }
 
-func updateSamlConfig(plan samlResourceModel, apiClient *client.APIClient, diagnostics *diag.Diagnostics) (*client.SamlSettingsResponseSchema, error) {
-	preSamlSettings, preHttpRes, preErr := apiClient.AuthAPI.GetSamlSettings(context.Background()).Execute()
+func updateSamlConfig(ctx context.Context, plan samlResourceModel, apiClient *client.APIClient, diagnostics *diag.Diagnostics) (*client.SamlSettingsResponseSchema, error) {
+	preSamlSettings, preHttpRes, preErr := apiClient.AuthAPI.GetSamlSettings(ctx).Execute()
 
 	if !ValidateApiResponse(preHttpRes, 200, diagnostics, preErr) {
 		return nil, preErr
@@ -213,14 +213,14 @@ func updateSamlConfig(plan samlResourceModel, apiClient *client.APIClient, diagn
 		SamlSettingsSchemaOneOf: innerSettings,
 	}
 
-	_, httpRes, err := apiClient.AuthAPI.SetSamlSettings(context.Background()).SamlSettingsSchema(samlSettings).Execute()
+	_, httpRes, err := apiClient.AuthAPI.SetSamlSettings(ctx).SamlSettingsSchema(samlSettings).Execute()
 
 	if !ValidateApiResponse(httpRes, 200, diagnostics, err) {
 		return nil, err
 	}
 
 	// Gotta do a second get because the response from the post is missing some fields
-	samlSettingsResponse, httpRes, err := apiClient.AuthAPI.GetSamlSettings(context.Background()).Execute()
+	samlSettingsResponse, httpRes, err := apiClient.AuthAPI.GetSamlSettings(ctx).Execute()
 
 	if !ValidateApiResponse(httpRes, 200, diagnostics, err) {
 		return nil, err

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -118,7 +118,11 @@ func testAccCheckUserResourceDestroy(s *terraform.State) error {
 	configuration.AddDefaultHeader("Authorization", authorization)
 	apiClient := unleash.NewAPIClient(configuration)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	timeoutSeconds := 30 // Default timeout
+	if envTimeout, err := strconv.Atoi(os.Getenv("TEST_TIMEOUT_SECONDS")); err == nil && envTimeout > 0 {
+		timeoutSeconds = envTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
 	// loop through the resources in state, verifying each widget

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	unleash "github.com/Unleash/unleash-server-api-go/client"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -116,6 +117,9 @@ func testAccCheckUserResourceDestroy(s *terraform.State) error {
 	configuration.HTTPClient = httpClient(false)
 	configuration.AddDefaultHeader("Authorization", authorization)
 	apiClient := unleash.NewAPIClient(configuration)
+	
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	// loop through the resources in state, verifying each widget
 	// is destroyed
@@ -129,7 +133,7 @@ func testAccCheckUserResourceDestroy(s *terraform.State) error {
 			return fmt.Errorf("Expected an integer")
 		}
 
-		user, response, err := apiClient.UsersAPI.GetUser(context.Background(), int32(userId)).Execute()
+		user, response, err := apiClient.UsersAPI.GetUser(ctx, int32(userId)).Execute()
 		if err == nil {
 			if fmt.Sprintf("%v", user.Id) == rs.Primary.ID {
 				return fmt.Errorf("User (%s) still exists.", rs.Primary.ID)

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -118,12 +118,6 @@ func testAccCheckUserResourceDestroy(s *terraform.State) error {
 	configuration.AddDefaultHeader("Authorization", authorization)
 	apiClient := unleash.NewAPIClient(configuration)
 
-	timeoutSeconds := 30 // Default timeout
-	if envTimeout, err := strconv.Atoi(os.Getenv("TEST_TIMEOUT_SECONDS")); err == nil && envTimeout > 0 {
-		timeoutSeconds = envTimeout
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds)*time.Second)
-	defer cancel()
 
 	// loop through the resources in state, verifying each widget
 	// is destroyed

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -117,7 +117,7 @@ func testAccCheckUserResourceDestroy(s *terraform.State) error {
 	configuration.HTTPClient = httpClient(false)
 	configuration.AddDefaultHeader("Authorization", authorization)
 	apiClient := unleash.NewAPIClient(configuration)
-	
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -131,7 +131,7 @@ func testAccCheckUserResourceDestroy(s *terraform.State) error {
 			return fmt.Errorf("Expected an integer")
 		}
 
-		user, response, err := apiClient.UsersAPI.GetUser(ctx, int32(userId)).Execute()
+		user, response, err := apiClient.UsersAPI.GetUser(context.Background(), int32(userId)).Execute()
 		if err == nil {
 			if fmt.Sprintf("%v", user.Id) == rs.Primary.ID {
 				return fmt.Errorf("User (%s) still exists.", rs.Primary.ID)

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strconv"
 	"testing"
-	"time"
 
 	unleash "github.com/Unleash/unleash-server-api-go/client"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -117,7 +116,6 @@ func testAccCheckUserResourceDestroy(s *terraform.State) error {
 	configuration.HTTPClient = httpClient(false)
 	configuration.AddDefaultHeader("Authorization", authorization)
 	apiClient := unleash.NewAPIClient(configuration)
-
 
 	// loop through the resources in state, verifying each widget
 	// is destroyed


### PR DESCRIPTION
Updated all CRUD operations across resources to use the provided `ctx` parameter instead of `context.Background()`, ensuring that:

- API calls respect Terraform's timeout and cancellation signals
- Database connections are properly cleaned up when operations are cancelled
- Connection pool resources are managed correctly during orchestrated Terraform workflows

This fix should resolve some of the connection pool exhaustion issues customers were experiencing with the Terraform provider while maintaining full compatibility with existing functionality.