### PR TITLE
fix: adapt user resource to expected terraform behavior

### DIFF
--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -190,9 +190,15 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	// Get fresh data
-	user, api_response, err := r.client.UsersAPI.GetUser(ctx, int32(userId)).Execute()
+	user, httpResponse, err := r.client.UsersAPI.GetUser(ctx, int32(userId)).Execute()
 
-	if !ValidateApiResponse(api_response, 200, &resp.Diagnostics, err) {
+	if httpResponse != nil && httpResponse.StatusCode == 404 {
+		tflog.Warn(ctx, fmt.Sprintf("User with id %s not found, removing from state", state.Id.ValueString()))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if !ValidateApiResponse(httpResponse, 200, &resp.Diagnostics, err) {
 		return
 	}
 


### PR DESCRIPTION
## About the changes
This PR adapts the read resource to align with the expectations from terraform providers from [this thread](https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/2).

As pointed out in the issue report:
* `IsValidApiResponse()` should return `false` without appending any error diagnostics when called from a `Read()` function (NB: it should be fine to emit a warning diagnostic here if you really want to)
* `IsValidApiResponse()` should probably return `false` _with_ an error diagnostic when called from a `Create()` function.

This PR adds another helper method that is used for reading resources that take into account the fact that they may no longer exist upstream, and then proceeds to delete them from the state so Terraform can handle them.

It's the same solution as #243, but without the breaking change

Fixes #236 