### PR TITLE
fix: handle legacy pro project environments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
 
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:
-    name: Terraform Provider Acceptance Tests
+    name: Acc Tests (TF ${{ matrix.terraform }}, ${{ contains(matrix.docker-image, 'unleash-enterprise') && 'enterprise' || 'oss' }}, Unleash ${{ endsWith(matrix.docker-image, ':latest') && 'latest' || endsWith(matrix.docker-image, ':6') && '6' || '5' }}${{ matrix.unleash-plan && format(', plan={0}', matrix.unleash-plan) || '' }})
     needs: [build]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -74,6 +74,12 @@ jobs:
           - "unleashorg/unleash-server:6"
           - "unleashorg/unleash-enterprise:latest"
           - "unleashorg/unleash-server:latest"
+        unleash-plan:
+          - ""
+        include:
+          - terraform: "1.4.*"
+            docker-image: "unleashorg/unleash-enterprise:latest"
+            unleash-plan: "pro"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
@@ -98,4 +104,5 @@ jobs:
           TF_ACC: "1"
           #TF_LOG: "debug"
           UNLEASH_ENTERPRISE: "${{ contains(matrix.docker-image, 'unleash-enterprise') }}"
+          UNLEASH_PLAN: ${{ matrix.unleash-plan }}
         timeout-minutes: 3

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ go install
 
 https://developer.hashicorp.com/terraform/plugin/testing
 
-**Note**: some tests rely on an enterprise version of Unleash. To run those tests locally you need to set the environment variable `UNLEASH_ENTERPRISE=true`. To run docker with an enterprise image: `UNLEASH_DOCKER_IMAGE=unleashorg/unleash-enterprise:latest docker compose up` (you will also need a valid license key that you can provide at startup with `UNLEASH_DEV_LICENSE=<your license key>`).
+**Note**: some tests rely on enterprise-compatible features in Unleash. To run those tests locally you need to set `UNLEASH_ENTERPRISE=true`. By default those tests assume the enterprise plan; to run the same suite against the Pro plan, also set `UNLEASH_PLAN=pro`. To run docker with an enterprise image: `UNLEASH_DOCKER_IMAGE=unleashorg/unleash-enterprise:latest docker compose up` (you will also need a valid license key that you can provide at startup with `UNLEASH_DEV_LICENSE=<your license key>`).
 
 Run tests (most likely we will not have a lot of unit tests but instead we'll have acceptance tests)
 
@@ -48,10 +48,16 @@ Run **acceptance tests** which cover the provider and resources code
 TF_LOG=debug TF_ACC=1 go test ./... -v -count=1
 ```
 
-To run enterprise tests (you have to make sure you're running an enterprise server)
+To run enterprise-compatible tests (you have to make sure you're running an enterprise server)
 
 ```shell
 UNLEASH_ENTERPRISE=true TF_LOG=debug TF_ACC=1 go test ./... -v -count=1
+```
+
+To run the same enterprise-compatible tests against the Pro plan
+
+```shell
+UNLEASH_ENTERPRISE=true UNLEASH_PLAN=pro TF_LOG=debug TF_ACC=1 go test ./... -v -count=1
 ```
 
 or the following make target (although it will cache results if nothing changes)

--- a/internal/provider/environment_resource_test.go
+++ b/internal/provider/environment_resource_test.go
@@ -1,16 +1,13 @@
 package provider
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccEnvironmentResource(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/group_resource_test.go
+++ b/internal/provider/group_resource_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -32,9 +31,7 @@ func customCheckGroupMappingSSOExists(resourceName string, mapping string) resou
 }
 
 func TestAccGroupResource(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -239,9 +236,7 @@ func TestAccGroupResource(t *testing.T) {
 
 // TestAccGroupResource_MinimalConfig tests creating a group with minimal configuration.
 func TestAccGroupResource_MinimalConfig(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -263,9 +258,7 @@ func TestAccGroupResource_MinimalConfig(t *testing.T) {
 
 // TestAccGroupResource_RemoveOptionalFields tests removing optional fields.
 func TestAccGroupResource_RemoveOptionalFields(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/oidc_resource_test.go
+++ b/internal/provider/oidc_resource_test.go
@@ -1,16 +1,13 @@
 package provider
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccOidcResource(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/permission_data_source_test.go
+++ b/internal/provider/permission_data_source_test.go
@@ -1,16 +1,13 @@
 package provider
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccPermissionDataSource(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/project_access_resource_test.go
+++ b/internal/provider/project_access_resource_test.go
@@ -1,16 +1,13 @@
 package provider
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccProjectAccessResource(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/project_environment_data_source.go
+++ b/internal/provider/project_environment_data_source.go
@@ -86,14 +86,44 @@ func (d *projectEnvironmentDataSource) Read(ctx context.Context, req datasource.
 		return
 	}
 
+	environments, getEnvironmentsResponse, getEnvironmentsErr := d.client.EnvironmentsAPI.GetProjectEnvironments(ctx, state.ProjectId.ValueString()).Execute()
+
+	if !ValidateApiResponse(getEnvironmentsResponse, 200, &resp.Diagnostics, getEnvironmentsErr) {
+		return
+	}
+
+	enabled := false
+	for _, env := range environments.Environments {
+		if env.Name == state.EnvironmentName.ValueString() {
+			enabled = true
+			break
+		}
+	}
+
+	if !enabled {
+		state.ChangeRequestsEnabled = types.BoolValue(false)
+		state.RequiredApprovals = types.Int64Null()
+		state.Enabled = types.BoolValue(false)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+		return
+	}
+
 	config, getResponse, getErr := d.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, state.ProjectId.ValueString()).Execute()
+	if isNotFoundResponse(getResponse) {
+		state.ProjectId = types.StringValue(state.ProjectId.ValueString())
+		state.EnvironmentName = types.StringValue(state.EnvironmentName.ValueString())
+		state.ChangeRequestsEnabled = types.BoolValue(false)
+		state.RequiredApprovals = types.Int64Null()
+		state.Enabled = types.BoolValue(true)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+		return
+	}
 
 	if !ValidateApiResponse(getResponse, 200, &resp.Diagnostics, getErr) {
 		return
 	}
 
 	var envChangeRequestConfig *unleash.ChangeRequestEnvironmentConfigSchema
-
 	for _, env := range config {
 		if env.Environment == state.EnvironmentName.ValueString() {
 			envChangeRequestConfig = &env
@@ -102,9 +132,11 @@ func (d *projectEnvironmentDataSource) Read(ctx context.Context, req datasource.
 	}
 
 	if envChangeRequestConfig == nil {
+		state.ProjectId = types.StringValue(state.ProjectId.ValueString())
+		state.EnvironmentName = types.StringValue(state.EnvironmentName.ValueString())
 		state.ChangeRequestsEnabled = types.BoolValue(false)
 		state.RequiredApprovals = types.Int64Null()
-		state.Enabled = types.BoolValue(false)
+		state.Enabled = types.BoolValue(true)
 		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 		return
 	}

--- a/internal/provider/project_environment_data_source.go
+++ b/internal/provider/project_environment_data_source.go
@@ -108,13 +108,14 @@ func (d *projectEnvironmentDataSource) Read(ctx context.Context, req datasource.
 		return
 	}
 
+	state.ProjectId = types.StringValue(state.ProjectId.ValueString())
+	state.EnvironmentName = types.StringValue(state.EnvironmentName.ValueString())
+	state.Enabled = types.BoolValue(true)
+
 	config, getResponse, getErr := d.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, state.ProjectId.ValueString()).Execute()
 	if isNotFoundResponse(getResponse) {
-		state.ProjectId = types.StringValue(state.ProjectId.ValueString())
-		state.EnvironmentName = types.StringValue(state.EnvironmentName.ValueString())
 		state.ChangeRequestsEnabled = types.BoolValue(false)
 		state.RequiredApprovals = types.Int64Null()
-		state.Enabled = types.BoolValue(true)
 		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 		return
 	}
@@ -132,11 +133,8 @@ func (d *projectEnvironmentDataSource) Read(ctx context.Context, req datasource.
 	}
 
 	if envChangeRequestConfig == nil {
-		state.ProjectId = types.StringValue(state.ProjectId.ValueString())
-		state.EnvironmentName = types.StringValue(state.EnvironmentName.ValueString())
 		state.ChangeRequestsEnabled = types.BoolValue(false)
 		state.RequiredApprovals = types.Int64Null()
-		state.Enabled = types.BoolValue(true)
 		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 		return
 	}
@@ -149,11 +147,8 @@ func (d *projectEnvironmentDataSource) Read(ctx context.Context, req datasource.
 		requiredApprovals = types.Int64Null()
 	}
 
-	state.ProjectId = types.StringValue(state.ProjectId.ValueString())
-	state.EnvironmentName = types.StringValue(state.EnvironmentName.ValueString())
 	state.ChangeRequestsEnabled = types.BoolValue(envChangeRequestConfig.ChangeRequestEnabled)
 	state.RequiredApprovals = requiredApprovals
-	state.Enabled = types.BoolValue(true)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	tflog.Debug(ctx, "Finished reading project environment change request", map[string]interface{}{"success": true})

--- a/internal/provider/project_environment_data_source_test.go
+++ b/internal/provider/project_environment_data_source_test.go
@@ -1,16 +1,13 @@
 package provider
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccProjectEnvironmentDataSource(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/project_environment_resource.go
+++ b/internal/provider/project_environment_resource.go
@@ -316,40 +316,55 @@ func (r *projectEnvironmentResource) configureProjectEnvironment(ctx context.Con
 }
 
 func (r *projectEnvironmentResource) hydrateState(ctx context.Context, state *projectEnvironmentResourceModel, diagnostics *diag.Diagnostics) bool {
-	environments, getEnvironmentsResponse, getEnvironmentsErr := r.client.EnvironmentsAPI.GetProjectEnvironments(ctx, state.ProjectId.ValueString()).Execute()
-	if !ValidateApiResponse(getEnvironmentsResponse, 200, diagnostics, getEnvironmentsErr) {
+	enabled, ok := r.projectEnvironmentIsEnabled(ctx, state.ProjectId.ValueString(), state.EnvironmentName.ValueString(), diagnostics)
+	if !ok {
 		return false
 	}
 
-	for _, environment := range environments.Environments {
-		if environment.Name != state.EnvironmentName.ValueString() {
-			continue
-		}
+	if !enabled {
+		diagnostics.AddError(
+			"Environment not found in project",
+			fmt.Sprintf("Environment %s is not enabled for project %s", state.EnvironmentName.ValueString(), state.ProjectId.ValueString()),
+		)
+		return false
+	}
 
-		if !shouldManageChangeRequests(state.ChangeRequestsEnabled, state.RequiredApprovals) {
-			state.normalizeUnmanagedChangeRequestConfig()
-			return true
-		}
-
-		config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, state.ProjectId.ValueString()).Execute()
-		if isNotFoundResponse(getResponse) {
-			state.syncChangeRequestConfigNotFound()
-			return true
-		}
-
-		if !ValidateApiResponse(getResponse, 200, diagnostics, getErr) {
-			return false
-		}
-
-		state.syncChangeRequestConfigFromApi(config)
+	if !shouldManageChangeRequests(state.ChangeRequestsEnabled, state.RequiredApprovals) {
+		state.normalizeUnmanagedChangeRequestConfig()
 		return true
 	}
 
-	diagnostics.AddError(
-		"Environment not found in project",
-		fmt.Sprintf("Environment %s is not enabled for project %s", state.EnvironmentName.ValueString(), state.ProjectId.ValueString()),
-	)
-	return false
+	return r.hydrateManagedChangeRequestState(ctx, state, diagnostics)
+}
+
+func (r *projectEnvironmentResource) projectEnvironmentIsEnabled(ctx context.Context, projectId string, envName string, diagnostics *diag.Diagnostics) (bool, bool) {
+	environments, getEnvironmentsResponse, getEnvironmentsErr := r.client.EnvironmentsAPI.GetProjectEnvironments(ctx, projectId).Execute()
+	if !ValidateApiResponse(getEnvironmentsResponse, 200, diagnostics, getEnvironmentsErr) {
+		return false, false
+	}
+
+	for _, environment := range environments.Environments {
+		if environment.Name == envName {
+			return true, true
+		}
+	}
+
+	return false, true
+}
+
+func (r *projectEnvironmentResource) hydrateManagedChangeRequestState(ctx context.Context, state *projectEnvironmentResourceModel, diagnostics *diag.Diagnostics) bool {
+	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, state.ProjectId.ValueString()).Execute()
+	if isNotFoundResponse(getResponse) {
+		state.syncChangeRequestConfigNotFound()
+		return true
+	}
+
+	if !ValidateApiResponse(getResponse, 200, diagnostics, getErr) {
+		return false
+	}
+
+	state.syncChangeRequestConfigFromApi(config)
+	return true
 }
 
 func (m *projectEnvironmentResourceModel) hydrateResponseFromApi(config []unleash.ChangeRequestEnvironmentConfigSchema) {

--- a/internal/provider/project_environment_resource.go
+++ b/internal/provider/project_environment_resource.go
@@ -192,7 +192,7 @@ func (r *projectEnvironmentResource) Read(ctx context.Context, req resource.Read
 	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, projectId).Execute()
 	if isNotFoundResponse(getResponse) {
 		tflog.Debug(ctx, "Change request configuration endpoint is not available for this project environment")
-		state.resetChangeRequestConfig()
+		state.syncChangeRequestConfigNotFound()
 		resp.State.Set(ctx, state)
 		return
 	}
@@ -201,7 +201,7 @@ func (r *projectEnvironmentResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	state.hydrateResponseFromApi(config)
+	state.syncChangeRequestConfigFromApi(config)
 
 	resp.State.Set(ctx, state)
 
@@ -311,7 +311,7 @@ func (r *projectEnvironmentResource) hydrateState(ctx context.Context, state *pr
 
 		config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, state.ProjectId.ValueString()).Execute()
 		if isNotFoundResponse(getResponse) {
-			state.resetChangeRequestConfig()
+			state.syncChangeRequestConfigNotFound()
 			return true
 		}
 
@@ -319,7 +319,7 @@ func (r *projectEnvironmentResource) hydrateState(ctx context.Context, state *pr
 			return false
 		}
 
-		state.hydrateResponseFromApi(config)
+		state.syncChangeRequestConfigFromApi(config)
 		return true
 	}
 
@@ -358,6 +358,22 @@ func (m *projectEnvironmentResourceModel) hydrateResponseFromApi(config []unleas
 	m.EnvironmentName = types.StringValue(m.EnvironmentName.ValueString())
 	m.ChangeRequestsEnabled = types.BoolValue(envChangeRequestConfig.ChangeRequestEnabled)
 	m.RequiredApprovals = requiredApprovals
+}
+
+func (m *projectEnvironmentResourceModel) syncChangeRequestConfigFromApi(config []unleash.ChangeRequestEnvironmentConfigSchema) {
+	if !shouldManageChangeRequests(m.ChangeRequestsEnabled, m.RequiredApprovals) {
+		return
+	}
+
+	m.hydrateResponseFromApi(config)
+}
+
+func (m *projectEnvironmentResourceModel) syncChangeRequestConfigNotFound() {
+	if !shouldManageChangeRequests(m.ChangeRequestsEnabled, m.RequiredApprovals) {
+		return
+	}
+
+	m.resetChangeRequestConfig()
 }
 
 func (m *projectEnvironmentResourceModel) resetChangeRequestConfig() {

--- a/internal/provider/project_environment_resource.go
+++ b/internal/provider/project_environment_resource.go
@@ -277,7 +277,7 @@ func (r *projectEnvironmentResource) configureProjectEnvironment(ctx context.Con
 		return false
 	}
 
-	if !hasConfiguredChangeRequestSettings(plan.ChangeRequestsEnabled, plan.RequiredApprovals) {
+	if !shouldManageChangeRequests(plan.ChangeRequestsEnabled, plan.RequiredApprovals) {
 		return true
 	}
 
@@ -361,18 +361,12 @@ func (m *projectEnvironmentResourceModel) hydrateResponseFromApi(config []unleas
 }
 
 func (m *projectEnvironmentResourceModel) resetChangeRequestConfig() {
-	m.ProjectId = types.StringValue(m.ProjectId.ValueString())
-	m.EnvironmentName = types.StringValue(m.EnvironmentName.ValueString())
 	m.ChangeRequestsEnabled = types.BoolValue(false)
 	m.RequiredApprovals = types.Int64Null()
 }
 
 func shouldManageChangeRequests(changeRequestsEnabled types.Bool, requiredApprovals types.Int64) bool {
 	return (!changeRequestsEnabled.IsNull() && !changeRequestsEnabled.IsUnknown()) || (!requiredApprovals.IsNull() && !requiredApprovals.IsUnknown())
-}
-
-func hasConfiguredChangeRequestSettings(changeRequestsEnabled types.Bool, requiredApprovals types.Int64) bool {
-	return shouldManageChangeRequests(changeRequestsEnabled, requiredApprovals)
 }
 
 func isNotFoundResponse(response *http.Response) bool {

--- a/internal/provider/project_environment_resource.go
+++ b/internal/provider/project_environment_resource.go
@@ -151,7 +151,11 @@ func (r *projectEnvironmentResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	resp.State.Set(ctx, plan)
+	plan.normalizeUnmanagedChangeRequestConfig()
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	tflog.Debug(ctx, "Finished setting project environment", map[string]interface{}{"success": true})
 }
@@ -189,11 +193,17 @@ func (r *projectEnvironmentResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
+	if !shouldManageChangeRequests(state.ChangeRequestsEnabled, state.RequiredApprovals) {
+		state.normalizeUnmanagedChangeRequestConfig()
+		resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+		return
+	}
+
 	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, projectId).Execute()
 	if isNotFoundResponse(getResponse) {
 		tflog.Debug(ctx, "Change request configuration endpoint is not available for this project environment")
 		state.syncChangeRequestConfigNotFound()
-		resp.State.Set(ctx, state)
+		resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 		return
 	}
 
@@ -203,7 +213,10 @@ func (r *projectEnvironmentResource) Read(ctx context.Context, req resource.Read
 
 	state.syncChangeRequestConfigFromApi(config)
 
-	resp.State.Set(ctx, state)
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	tflog.Debug(ctx, "Finished reading project environment change request", map[string]interface{}{"success": true})
 }
@@ -226,7 +239,11 @@ func (r *projectEnvironmentResource) Update(ctx context.Context, req resource.Up
 		return
 	}
 
-	resp.State.Set(ctx, plan)
+	plan.normalizeUnmanagedChangeRequestConfig()
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	tflog.Debug(ctx, "Finished updating project environment change request", map[string]interface{}{"success": true})
 }
@@ -309,6 +326,11 @@ func (r *projectEnvironmentResource) hydrateState(ctx context.Context, state *pr
 			continue
 		}
 
+		if !shouldManageChangeRequests(state.ChangeRequestsEnabled, state.RequiredApprovals) {
+			state.normalizeUnmanagedChangeRequestConfig()
+			return true
+		}
+
 		config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, state.ProjectId.ValueString()).Execute()
 		if isNotFoundResponse(getResponse) {
 			state.syncChangeRequestConfigNotFound()
@@ -379,6 +401,19 @@ func (m *projectEnvironmentResourceModel) syncChangeRequestConfigNotFound() {
 func (m *projectEnvironmentResourceModel) resetChangeRequestConfig() {
 	m.ChangeRequestsEnabled = types.BoolValue(false)
 	m.RequiredApprovals = types.Int64Null()
+}
+
+func (m *projectEnvironmentResourceModel) normalizeUnmanagedChangeRequestConfig() {
+	if shouldManageChangeRequests(m.ChangeRequestsEnabled, m.RequiredApprovals) {
+		return
+	}
+
+	if m.ChangeRequestsEnabled.IsUnknown() {
+		m.ChangeRequestsEnabled = types.BoolNull()
+	}
+	if m.RequiredApprovals.IsUnknown() {
+		m.RequiredApprovals = types.Int64Null()
+	}
 }
 
 func shouldManageChangeRequests(changeRequestsEnabled types.Bool, requiredApprovals types.Int64) bool {

--- a/internal/provider/project_environment_resource.go
+++ b/internal/provider/project_environment_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	unleash "github.com/Unleash/unleash-server-api-go/client"
@@ -145,14 +146,10 @@ func (r *projectEnvironmentResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, plan.ProjectId.ValueString()).Execute()
-
-	if !ValidateApiResponse(getResponse, 200, &resp.Diagnostics, getErr) {
-		tflog.Warn(ctx, fmt.Sprintf("Failed to get project change request config for project %s", plan.ProjectId.ValueString()))
+	if !r.hydrateState(ctx, &plan, &resp.Diagnostics) {
+		tflog.Warn(ctx, fmt.Sprintf("Failed to hydrate project environment state for project %s", plan.ProjectId.ValueString()))
 		return
 	}
-
-	plan.hydrateResponseFromApi(config)
 
 	resp.State.Set(ctx, plan)
 
@@ -172,23 +169,35 @@ func (r *projectEnvironmentResource) Read(ctx context.Context, req resource.Read
 	projectId := state.ProjectId.ValueString()
 	envName := state.EnvironmentName.ValueString()
 
-	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, projectId).Execute()
+	environments, getEnvironmentsResponse, getEnvironmentsErr := r.client.EnvironmentsAPI.GetProjectEnvironments(ctx, projectId).Execute()
 
-	if !ValidateReadApiResponse(ctx, getResponse, getErr, resp, projectId, "Project") {
+	if !ValidateReadApiResponse(ctx, getEnvironmentsResponse, getEnvironmentsErr, resp, projectId, "Project") {
 		return
 	}
 
-	var envChangeRequestConfig *unleash.ChangeRequestEnvironmentConfigSchema
-	for i := range config {
-		if config[i].Environment == envName {
-			envChangeRequestConfig = &config[i]
+	enabled := false
+	for i := range environments.Environments {
+		if environments.Environments[i].Name == envName {
+			enabled = true
 			break
 		}
 	}
 
-	if envChangeRequestConfig == nil {
+	if !enabled {
 		tflog.Warn(ctx, fmt.Sprintf("Environment %s not found in project %s, removing from state", envName, projectId))
 		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, projectId).Execute()
+	if isNotFoundResponse(getResponse) {
+		tflog.Debug(ctx, "Change request configuration endpoint is not available for this project environment")
+		state.resetChangeRequestConfig()
+		resp.State.Set(ctx, state)
+		return
+	}
+
+	if !ValidateApiResponse(getResponse, 200, &resp.Diagnostics, getErr) {
 		return
 	}
 
@@ -213,13 +222,9 @@ func (r *projectEnvironmentResource) Update(ctx context.Context, req resource.Up
 		return
 	}
 
-	config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, plan.ProjectId.ValueString()).Execute()
-
-	if !ValidateApiResponse(getResponse, 200, &resp.Diagnostics, getErr) {
+	if !r.hydrateState(ctx, &plan, &resp.Diagnostics) {
 		return
 	}
-
-	plan.hydrateResponseFromApi(config)
 
 	resp.State.Set(ctx, plan)
 
@@ -236,14 +241,16 @@ func (r *projectEnvironmentResource) Delete(ctx context.Context, req resource.De
 		return
 	}
 
-	disableChangeRequest := *unleash.NewUpdateChangeRequestEnvironmentConfigSchemaWithDefaults()
-	disableChangeRequest.ChangeRequestsEnabled = false
-	disableChangeRequest.SetRequiredApprovals(0)
+	if shouldManageChangeRequests(state.ChangeRequestsEnabled, state.RequiredApprovals) {
+		disableChangeRequest := *unleash.NewUpdateChangeRequestEnvironmentConfigSchemaWithDefaults()
+		disableChangeRequest.ChangeRequestsEnabled = false
+		disableChangeRequest.SetRequiredApprovals(0)
 
-	updateResponse, updateErr := r.client.ChangeRequestsAPI.UpdateProjectChangeRequestConfig(ctx, state.ProjectId.ValueString(), state.EnvironmentName.ValueString()).UpdateChangeRequestEnvironmentConfigSchema(disableChangeRequest).Execute()
+		updateResponse, updateErr := r.client.ChangeRequestsAPI.UpdateProjectChangeRequestConfig(ctx, state.ProjectId.ValueString(), state.EnvironmentName.ValueString()).UpdateChangeRequestEnvironmentConfigSchema(disableChangeRequest).Execute()
 
-	if !ValidateApiResponse(updateResponse, 204, &resp.Diagnostics, updateErr) {
-		return
+		if !isNotFoundResponse(updateResponse) && !ValidateApiResponse(updateResponse, 204, &resp.Diagnostics, updateErr) {
+			return
+		}
 	}
 
 	deleteResponse, err := r.client.ProjectsAPI.RemoveEnvironmentFromProject(ctx, state.ProjectId.ValueString(), state.EnvironmentName.ValueString()).Execute()
@@ -270,6 +277,10 @@ func (r *projectEnvironmentResource) configureProjectEnvironment(ctx context.Con
 		return false
 	}
 
+	if !hasConfiguredChangeRequestSettings(plan.ChangeRequestsEnabled, plan.RequiredApprovals) {
+		return true
+	}
+
 	enableChangeRequest := *unleash.NewUpdateChangeRequestEnvironmentConfigSchemaWithDefaults()
 	enableChangeRequest.SetChangeRequestsEnabled(plan.ChangeRequestsEnabled.ValueBool())
 	if !plan.RequiredApprovals.IsNull() && plan.RequiredApprovals.ValueInt64Pointer() != nil {
@@ -285,6 +296,38 @@ func (r *projectEnvironmentResource) configureProjectEnvironment(ctx context.Con
 	}
 	tflog.Debug(ctx, fmt.Sprintf("Successfully configured project environment %s for project %s with change requests enabled %t", plan.EnvironmentName.ValueString(), plan.ProjectId.ValueString(), plan.ChangeRequestsEnabled.ValueBool()))
 	return true
+}
+
+func (r *projectEnvironmentResource) hydrateState(ctx context.Context, state *projectEnvironmentResourceModel, diagnostics *diag.Diagnostics) bool {
+	environments, getEnvironmentsResponse, getEnvironmentsErr := r.client.EnvironmentsAPI.GetProjectEnvironments(ctx, state.ProjectId.ValueString()).Execute()
+	if !ValidateApiResponse(getEnvironmentsResponse, 200, diagnostics, getEnvironmentsErr) {
+		return false
+	}
+
+	for _, environment := range environments.Environments {
+		if environment.Name != state.EnvironmentName.ValueString() {
+			continue
+		}
+
+		config, getResponse, getErr := r.client.ChangeRequestsAPI.GetProjectChangeRequestConfig(ctx, state.ProjectId.ValueString()).Execute()
+		if isNotFoundResponse(getResponse) {
+			state.resetChangeRequestConfig()
+			return true
+		}
+
+		if !ValidateApiResponse(getResponse, 200, diagnostics, getErr) {
+			return false
+		}
+
+		state.hydrateResponseFromApi(config)
+		return true
+	}
+
+	diagnostics.AddError(
+		"Environment not found in project",
+		fmt.Sprintf("Environment %s is not enabled for project %s", state.EnvironmentName.ValueString(), state.ProjectId.ValueString()),
+	)
+	return false
 }
 
 func (m *projectEnvironmentResourceModel) hydrateResponseFromApi(config []unleash.ChangeRequestEnvironmentConfigSchema) {
@@ -315,4 +358,23 @@ func (m *projectEnvironmentResourceModel) hydrateResponseFromApi(config []unleas
 	m.EnvironmentName = types.StringValue(m.EnvironmentName.ValueString())
 	m.ChangeRequestsEnabled = types.BoolValue(envChangeRequestConfig.ChangeRequestEnabled)
 	m.RequiredApprovals = requiredApprovals
+}
+
+func (m *projectEnvironmentResourceModel) resetChangeRequestConfig() {
+	m.ProjectId = types.StringValue(m.ProjectId.ValueString())
+	m.EnvironmentName = types.StringValue(m.EnvironmentName.ValueString())
+	m.ChangeRequestsEnabled = types.BoolValue(false)
+	m.RequiredApprovals = types.Int64Null()
+}
+
+func shouldManageChangeRequests(changeRequestsEnabled types.Bool, requiredApprovals types.Int64) bool {
+	return (!changeRequestsEnabled.IsNull() && !changeRequestsEnabled.IsUnknown()) || (!requiredApprovals.IsNull() && !requiredApprovals.IsUnknown())
+}
+
+func hasConfiguredChangeRequestSettings(changeRequestsEnabled types.Bool, requiredApprovals types.Int64) bool {
+	return shouldManageChangeRequests(changeRequestsEnabled, requiredApprovals)
+}
+
+func isNotFoundResponse(response *http.Response) bool {
+	return response != nil && response.StatusCode == http.StatusNotFound
 }

--- a/internal/provider/project_environment_resource_test.go
+++ b/internal/provider/project_environment_resource_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"os"
 	"regexp"
 	"testing"
 
@@ -9,9 +8,7 @@ import (
 )
 
 func TestAccProjectChangeRequestResource(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -133,9 +130,7 @@ func TestAccProjectChangeRequestResource(t *testing.T) {
 	})
 }
 func TestAccProjectEnvironmentImport(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/project_environment_resource_unit_test.go
+++ b/internal/provider/project_environment_resource_unit_test.go
@@ -1,0 +1,80 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestShouldManageChangeRequests(t *testing.T) {
+	tests := []struct {
+		name                  string
+		changeRequestsEnabled types.Bool
+		requiredApprovals     types.Int64
+		expected              bool
+	}{
+		{
+			name:                  "null bool with null approvals does not manage change requests",
+			changeRequestsEnabled: types.BoolNull(),
+			requiredApprovals:     types.Int64Null(),
+			expected:              false,
+		},
+		{
+			name:                  "enabled change requests are managed",
+			changeRequestsEnabled: types.BoolValue(true),
+			requiredApprovals:     types.Int64Null(),
+			expected:              true,
+		},
+		{
+			name:                  "explicitly disabling change requests is managed",
+			changeRequestsEnabled: types.BoolValue(false),
+			requiredApprovals:     types.Int64Null(),
+			expected:              true,
+		},
+		{
+			name:                  "required approvals imply change request management",
+			changeRequestsEnabled: types.BoolValue(false),
+			requiredApprovals:     types.Int64Value(2),
+			expected:              true,
+		},
+		{
+			name:                  "unknown approvals do not imply change request management",
+			changeRequestsEnabled: types.BoolNull(),
+			requiredApprovals:     types.Int64Unknown(),
+			expected:              false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := shouldManageChangeRequests(test.changeRequestsEnabled, test.requiredApprovals)
+			if actual != test.expected {
+				t.Fatalf("expected %t, got %t", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestResetChangeRequestConfig(t *testing.T) {
+	model := projectEnvironmentResourceModel{
+		ProjectId:             types.StringValue("project"),
+		EnvironmentName:       types.StringValue("development"),
+		ChangeRequestsEnabled: types.BoolValue(true),
+		RequiredApprovals:     types.Int64Value(3),
+	}
+
+	model.resetChangeRequestConfig()
+
+	if model.ProjectId.ValueString() != "project" {
+		t.Fatalf("expected project id to be preserved, got %s", model.ProjectId.ValueString())
+	}
+	if model.EnvironmentName.ValueString() != "development" {
+		t.Fatalf("expected environment name to be preserved, got %s", model.EnvironmentName.ValueString())
+	}
+	if model.ChangeRequestsEnabled.ValueBool() {
+		t.Fatal("expected change requests to be disabled")
+	}
+	if !model.RequiredApprovals.IsNull() {
+		t.Fatal("expected required approvals to be null")
+	}
+}

--- a/internal/provider/project_environment_resource_unit_test.go
+++ b/internal/provider/project_environment_resource_unit_test.go
@@ -122,3 +122,39 @@ func TestSyncChangeRequestConfigNotFoundPreservesUnmanagedState(t *testing.T) {
 		t.Fatal("expected required approvals to remain null for unmanaged state")
 	}
 }
+
+func TestNormalizeUnmanagedChangeRequestConfig(t *testing.T) {
+	model := projectEnvironmentResourceModel{
+		ProjectId:             types.StringValue("project"),
+		EnvironmentName:       types.StringValue("development"),
+		ChangeRequestsEnabled: types.BoolUnknown(),
+		RequiredApprovals:     types.Int64Unknown(),
+	}
+
+	model.normalizeUnmanagedChangeRequestConfig()
+
+	if !model.ChangeRequestsEnabled.IsNull() {
+		t.Fatal("expected change requests enabled to normalize to null for unmanaged state")
+	}
+	if !model.RequiredApprovals.IsNull() {
+		t.Fatal("expected required approvals to normalize to null for unmanaged state")
+	}
+}
+
+func TestNormalizeUnmanagedChangeRequestConfigPreservesManagedState(t *testing.T) {
+	model := projectEnvironmentResourceModel{
+		ProjectId:             types.StringValue("project"),
+		EnvironmentName:       types.StringValue("development"),
+		ChangeRequestsEnabled: types.BoolValue(false),
+		RequiredApprovals:     types.Int64Null(),
+	}
+
+	model.normalizeUnmanagedChangeRequestConfig()
+
+	if model.ChangeRequestsEnabled.IsNull() {
+		t.Fatal("expected managed change requests enabled to be preserved")
+	}
+	if model.ChangeRequestsEnabled.ValueBool() {
+		t.Fatal("expected explicit false value to be preserved")
+	}
+}

--- a/internal/provider/project_environment_resource_unit_test.go
+++ b/internal/provider/project_environment_resource_unit_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"testing"
 
+	unleash "github.com/Unleash/unleash-server-api-go/client"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -76,5 +77,48 @@ func TestResetChangeRequestConfig(t *testing.T) {
 	}
 	if !model.RequiredApprovals.IsNull() {
 		t.Fatal("expected required approvals to be null")
+	}
+}
+
+func TestSyncChangeRequestConfigFromApiPreservesUnmanagedState(t *testing.T) {
+	model := projectEnvironmentResourceModel{
+		ProjectId:             types.StringValue("project"),
+		EnvironmentName:       types.StringValue("development"),
+		ChangeRequestsEnabled: types.BoolNull(),
+		RequiredApprovals:     types.Int64Null(),
+	}
+	requiredApprovals := float32(2)
+
+	model.syncChangeRequestConfigFromApi([]unleash.ChangeRequestEnvironmentConfigSchema{
+		{
+			Environment:          "development",
+			ChangeRequestEnabled: true,
+			RequiredApprovals:    *unleash.NewNullableFloat32(&requiredApprovals),
+		},
+	})
+
+	if !model.ChangeRequestsEnabled.IsNull() {
+		t.Fatal("expected change requests enabled to remain null for unmanaged state")
+	}
+	if !model.RequiredApprovals.IsNull() {
+		t.Fatal("expected required approvals to remain null for unmanaged state")
+	}
+}
+
+func TestSyncChangeRequestConfigNotFoundPreservesUnmanagedState(t *testing.T) {
+	model := projectEnvironmentResourceModel{
+		ProjectId:             types.StringValue("project"),
+		EnvironmentName:       types.StringValue("development"),
+		ChangeRequestsEnabled: types.BoolNull(),
+		RequiredApprovals:     types.Int64Null(),
+	}
+
+	model.syncChangeRequestConfigNotFound()
+
+	if !model.ChangeRequestsEnabled.IsNull() {
+		t.Fatal("expected change requests enabled to remain null for unmanaged state")
+	}
+	if !model.RequiredApprovals.IsNull() {
+		t.Fatal("expected required approvals to remain null for unmanaged state")
 	}
 }

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -86,9 +85,7 @@ func testAccSampleProjectResourceWithUpdatedEnterpriseSettings(name string, id s
 }
 
 func TestAccProjectResource(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 
 	randomID := func() string {
 		return fmt.Sprintf("tf-acc-%s", strings.ToLower(acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)))

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -38,6 +39,45 @@ func testAccPreCheck(_ *testing.T) {
 	envOrDefault("UNLEASH_URL", "http://localhost:4242")
 	envOrDefault("AUTH_TOKEN", "*:*.unleash-insecure-admin-api-token")
 	envOrDefault("UNLEASH_ENTERPRISE", "false")
+}
+
+func currentUnleashPlan() string {
+	plan := strings.ToLower(os.Getenv("UNLEASH_PLAN"))
+	if plan != "" {
+		return plan
+	}
+
+	if os.Getenv("UNLEASH_ENTERPRISE") == "true" {
+		return "enterprise"
+	}
+
+	return "oss"
+}
+
+func supportsEnterpriseAcceptanceTests() bool {
+	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
+		return false
+	}
+
+	switch currentUnleashPlan() {
+	case "enterprise", "pro":
+		return true
+	default:
+		return false
+	}
+}
+
+func skipUnlessEnterpriseCompatiblePlan(t *testing.T) {
+	t.Helper()
+
+	if supportsEnterpriseAcceptanceTests() {
+		return
+	}
+
+	t.Skipf(
+		"Skipping enterprise-compatible tests (requires UNLEASH_ENTERPRISE=true and UNLEASH_PLAN=enterprise or pro, got UNLEASH_PLAN=%q)",
+		currentUnleashPlan(),
+	)
 }
 
 func Test_provider_checkIsSupportedVersion_556(t *testing.T) {
@@ -93,4 +133,44 @@ func Test_unleashClient_setsUnleashHeaders(t *testing.T) {
 		assert.NotContains(t, headers, "X-Unleash-InstanceId")
 		assert.Equal(t, UserAgent+"/"+p.version, cfg.UserAgent)
 	}
+}
+
+func Test_currentUnleashPlan(t *testing.T) {
+	t.Run("defaults to oss", func(t *testing.T) {
+		t.Setenv("UNLEASH_ENTERPRISE", "false")
+		t.Setenv("UNLEASH_PLAN", "")
+		assert.Equal(t, "oss", currentUnleashPlan())
+	})
+
+	t.Run("defaults to enterprise when enterprise env is set", func(t *testing.T) {
+		t.Setenv("UNLEASH_ENTERPRISE", "true")
+		t.Setenv("UNLEASH_PLAN", "")
+		assert.Equal(t, "enterprise", currentUnleashPlan())
+	})
+
+	t.Run("uses explicit plan", func(t *testing.T) {
+		t.Setenv("UNLEASH_ENTERPRISE", "true")
+		t.Setenv("UNLEASH_PLAN", "PrO")
+		assert.Equal(t, "pro", currentUnleashPlan())
+	})
+}
+
+func Test_supportsEnterpriseAcceptanceTests(t *testing.T) {
+	t.Run("oss does not support enterprise acceptance tests", func(t *testing.T) {
+		t.Setenv("UNLEASH_ENTERPRISE", "false")
+		t.Setenv("UNLEASH_PLAN", "")
+		assert.False(t, supportsEnterpriseAcceptanceTests())
+	})
+
+	t.Run("enterprise plan supports enterprise acceptance tests", func(t *testing.T) {
+		t.Setenv("UNLEASH_ENTERPRISE", "true")
+		t.Setenv("UNLEASH_PLAN", "enterprise")
+		assert.True(t, supportsEnterpriseAcceptanceTests())
+	})
+
+	t.Run("pro plan supports enterprise acceptance tests", func(t *testing.T) {
+		t.Setenv("UNLEASH_ENTERPRISE", "true")
+		t.Setenv("UNLEASH_PLAN", "pro")
+		assert.True(t, supportsEnterpriseAcceptanceTests())
+	})
 }

--- a/internal/provider/role_data_source_test.go
+++ b/internal/provider/role_data_source_test.go
@@ -1,16 +1,13 @@
 package provider
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccRoleDataSource(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/role_resource_test.go
+++ b/internal/provider/role_resource_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -41,9 +40,7 @@ func customCheckRolePermissionExists(resourceName string, permissionName string,
 }
 
 func TestAccRoleResource(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/saml_resource_test.go
+++ b/internal/provider/saml_resource_test.go
@@ -1,16 +1,13 @@
 package provider
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccSamlResource(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/service_account_resource_test.go
+++ b/internal/provider/service_account_resource_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -18,9 +17,7 @@ func makeServiceAccountDef(name string, user_name string, root_role int32) strin
 }
 
 func TestAccServiceAccountResource(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/service_account_tokens_resource_test.go
+++ b/internal/provider/service_account_tokens_resource_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -10,9 +9,7 @@ import (
 )
 
 func TestAccServiceAccountTokenResource(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -44,10 +41,7 @@ func TestAccServiceAccountTokenResource(t *testing.T) {
 }
 
 func TestAccServiceAccountTokenResourceUpdatingDescriptionGeneratesNewToken(t *testing.T) {
-
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"testing"
 
@@ -75,9 +74,7 @@ resource "unleash_user" "%s" {
 }`, resource, name)
 }
 func TestAccUserResource(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -135,9 +132,7 @@ func TestAccUserResource(t *testing.T) {
 }
 
 func TestAccUserResourceImport(t *testing.T) {
-	if os.Getenv("UNLEASH_ENTERPRISE") != "true" {
-		t.Skip("Skipping enterprise tests")
-	}
+	skipUnlessEnterpriseCompatiblePlan(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,


### PR DESCRIPTION
## What changed
This updates `unleash_project_environment` so the provider only writes change-request configuration when that configuration is explicitly set in Terraform. It also keeps reads working on legacy Pro tenants where the change-request endpoint is not available.

## Why it changed
A customer on a legacy Pro hosted plan can enable project environments, but does not have access to the `change-requests/config` endpoint. The provider was enabling the environment successfully and then failing on that follow-up call even when the Terraform config did not request any change-request settings.

## Impact
Users who only want to attach an environment to a project no longer fail on legacy Pro plans. If a configuration explicitly requests change-request settings and the endpoint is unavailable, the provider still fails instead of silently masking that mismatch.

## Root cause
The resource mixed two concerns in one flow: environment membership and change-request configuration. The write path always attempted both, but the second endpoint is not available on every plan that can still use the first endpoint.

## Validation
- `go test ./internal/provider/...`
