### PR TITLE
chore: reduce concurrency by default to 2

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,3 +28,4 @@ provider "unleash" {
 
 - `authorization` (String, Sensitive) Authorization token for Unleash API
 - `base_url` (String) Unleash base URL (everything before `/api`)
+- `max_concurrent_requests` (Number) Maximum number of concurrent HTTP requests the provider sends to the Unleash API. Defaults to `2`, which is the recommended value for most Unleash deployments. Increasing this value can overload Unleash instances with small database connection pools and should only be done when the backend capacity is known to support it. Can also be set with `UNLEASH_MAX_CONCURRENT_REQUESTS`.

--- a/internal/provider/http_transport.go
+++ b/internal/provider/http_transport.go
@@ -2,18 +2,72 @@ package provider
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httputil"
+	"sync"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func httpClient(debug bool) *http.Client {
+func httpClient(debug bool, maxConcurrentRequests int64) *http.Client {
 	return &http.Client{
-		Transport: &debugTransport{
-			Transport:   http.DefaultTransport,
-			EnableDebug: debug,
+		Transport: &concurrentRequestTransport{
+			Transport: newDebugTransport(debug),
+			limit:     make(chan struct{}, maxConcurrentRequests),
 		},
+	}
+}
+
+type concurrentRequestTransport struct {
+	Transport http.RoundTripper
+	limit     chan struct{}
+}
+
+func (t *concurrentRequestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	select {
+	case t.limit <- struct{}{}:
+	case <-req.Context().Done():
+		return nil, req.Context().Err()
+	}
+
+	resp, err := t.Transport.RoundTrip(req)
+	if err != nil || resp == nil || resp.Body == nil {
+		t.release()
+		return resp, err
+	}
+
+	resp.Body = &releaseOnCloseReadCloser{
+		ReadCloser: resp.Body,
+		release:    t.release,
+	}
+
+	return resp, err
+}
+
+func (t *concurrentRequestTransport) release() {
+	<-t.limit
+}
+
+type releaseOnCloseReadCloser struct {
+	io.ReadCloser
+	release func()
+	once    sync.Once
+}
+
+func (r *releaseOnCloseReadCloser) Close() error {
+	var err error
+	r.once.Do(func() {
+		err = r.ReadCloser.Close()
+		r.release()
+	})
+	return err
+}
+
+func newDebugTransport(debug bool) http.RoundTripper {
+	return &debugTransport{
+		Transport:   http.DefaultTransport,
+		EnableDebug: debug,
 	}
 }
 
@@ -37,8 +91,10 @@ func (t *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	if t.EnableDebug {
 		// Log the response details
-		responseDump, _ := httputil.DumpResponse(resp, true)
-		tflog.Debug(req.Context(), fmt.Sprintf("Response:\n%s", responseDump))
+		if resp != nil {
+			responseDump, _ := httputil.DumpResponse(resp, true)
+			tflog.Debug(req.Context(), fmt.Sprintf("Response:\n%s", responseDump))
+		}
 	}
 
 	return resp, err

--- a/internal/provider/http_transport.go
+++ b/internal/provider/http_transport.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func httpClient(debug bool, maxConcurrentRequests int64) *http.Client {
+func httpClient(debug bool, maxConcurrentRequests int) *http.Client {
 	return &http.Client{
 		Transport: &concurrentRequestTransport{
 			Transport: newDebugTransport(debug),

--- a/internal/provider/http_transport_test.go
+++ b/internal/provider/http_transport_test.go
@@ -60,8 +60,8 @@ func Test_concurrentRequestTransport_limitsRequestsUntilResponseBodyIsClosed(t *
 		}()
 	}
 
-	first := <-acquired
-	second := <-acquired
+	<-acquired
+	<-acquired
 
 	select {
 	case resp := <-acquired:

--- a/internal/provider/http_transport_test.go
+++ b/internal/provider/http_transport_test.go
@@ -1,0 +1,74 @@
+package provider
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type staticResponseTransport struct{}
+
+func (t staticResponseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("ok")),
+		Request:    req,
+	}, nil
+}
+
+func Test_concurrentRequestTransport_limitsRequestsUntilResponseBodyIsClosed(t *testing.T) {
+	transport := &concurrentRequestTransport{
+		Transport: staticResponseTransport{},
+		limit:     make(chan struct{}, 2),
+	}
+	client := &http.Client{Transport: transport}
+
+	acquired := make(chan *http.Response, 5)
+	errs := make(chan error, 5)
+	closeBodies := make(chan struct{})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			resp, err := client.Get("http://example.com")
+			if err != nil {
+				errs <- err
+				return
+			}
+
+			acquired <- resp
+			<-closeBodies
+			errs <- resp.Body.Close()
+		}()
+	}
+
+	first := <-acquired
+	second := <-acquired
+
+	select {
+	case resp := <-acquired:
+		require.NoError(t, resp.Body.Close())
+		t.Fatal("request was not throttled while prior response bodies were still open")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(closeBodies)
+	wg.Wait()
+	close(errs)
+
+	require.NoError(t, first.Body.Close())
+	require.NoError(t, second.Body.Close())
+	for err := range errs {
+		assert.NoError(t, err)
+	}
+	assert.Empty(t, transport.limit)
+}

--- a/internal/provider/http_transport_test.go
+++ b/internal/provider/http_transport_test.go
@@ -32,6 +32,15 @@ func Test_concurrentRequestTransport_limitsRequestsUntilResponseBodyIsClosed(t *
 	acquired := make(chan *http.Response, 5)
 	errs := make(chan error, 5)
 	closeBodies := make(chan struct{})
+	var closeBodiesOnce sync.Once
+	unblockBodies := func() {
+		closeBodiesOnce.Do(func() {
+			close(closeBodies)
+		})
+	}
+	t.Cleanup(func() {
+		unblockBodies()
+	})
 
 	var wg sync.WaitGroup
 	for i := 0; i < 5; i++ {
@@ -61,7 +70,7 @@ func Test_concurrentRequestTransport_limitsRequestsUntilResponseBodyIsClosed(t *
 	case <-time.After(50 * time.Millisecond):
 	}
 
-	close(closeBodies)
+	unblockBodies()
 	wg.Wait()
 	close(errs)
 

--- a/internal/provider/http_transport_test.go
+++ b/internal/provider/http_transport_test.go
@@ -74,8 +74,6 @@ func Test_concurrentRequestTransport_limitsRequestsUntilResponseBodyIsClosed(t *
 	wg.Wait()
 	close(errs)
 
-	require.NoError(t, first.Body.Close())
-	require.NoError(t, second.Body.Close())
 	for err := range errs {
 		assert.NoError(t, err)
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	unleash "github.com/Unleash/unleash-server-api-go/client"
@@ -41,8 +42,9 @@ const (
 
 // ScaffoldingProviderMofunc (p *UnleashProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {del describes the provider data model.
 type UnleashConfiguration struct {
-	BaseUrl       types.String `tfsdk:"base_url"`
-	Authorization types.String `tfsdk:"authorization"`
+	BaseUrl               types.String `tfsdk:"base_url"`
+	Authorization         types.String `tfsdk:"authorization"`
+	MaxConcurrentRequests types.Int64  `tfsdk:"max_concurrent_requests"`
 }
 
 func (p *UnleashProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -55,6 +57,7 @@ func unleashClient(ctx context.Context, provider *UnleashProvider, config *Unlea
 	authorization := configValue(config.Authorization, "AUTH_TOKEN", "UNLEASH_AUTH_TOKEN")
 	mustHave("base_url", base_url, diagnostics)
 	mustHave("authorization", authorization, diagnostics)
+	maxRequests := maxConcurrentRequests(config.MaxConcurrentRequests, diagnostics)
 
 	if diagnostics.HasError() {
 		return nil
@@ -76,7 +79,7 @@ func unleashClient(ctx context.Context, provider *UnleashProvider, config *Unlea
 
 	logLevel := strings.ToLower(os.Getenv("TF_LOG"))
 	isDebug := logLevel == "debug" || logLevel == "trace"
-	unleashConfig.HTTPClient = httpClient(isDebug)
+	unleashConfig.HTTPClient = httpClient(isDebug, maxRequests)
 	client := unleash.NewAPIClient(unleashConfig)
 
 	return client
@@ -93,6 +96,10 @@ func (p *UnleashProvider) Schema(ctx context.Context, req provider.SchemaRequest
 				MarkdownDescription: "Authorization token for Unleash API",
 				Optional:            true,
 				Sensitive:           true,
+			},
+			"max_concurrent_requests": schema.Int64Attribute{
+				MarkdownDescription: "Maximum number of concurrent HTTP requests the provider sends to the Unleash API. Defaults to `2`, which is the recommended value for most Unleash deployments. Increasing this value can overload Unleash instances with small database connection pools and should only be done when the backend capacity is known to support it. Can also be set with `UNLEASH_MAX_CONCURRENT_REQUESTS`.",
+				Optional:            true,
 			},
 		},
 		MarkdownDescription: `Interface with [Unleash server API](https://docs.getunleash.io/reference/api/unleash). This provider implements a subset of the operations that can be done with Unleash. The focus is mostly in setting up the instance with projects, roles, permissions, groups, and other typical configuration usually performed by admins.
@@ -119,6 +126,36 @@ func mustHave(name string, value string, diagnostics *diag.Diagnostics) {
 			name+" cannot be an empty string",
 		)
 	}
+}
+
+func maxConcurrentRequests(configValue basetypes.Int64Value, diagnostics *diag.Diagnostics) int64 {
+	value := int64(2)
+
+	if envValue := os.Getenv("UNLEASH_MAX_CONCURRENT_REQUESTS"); envValue != "" {
+		parsed, err := strconv.ParseInt(envValue, 10, 64)
+		if err != nil {
+			diagnostics.AddError(
+				"Invalid UNLEASH_MAX_CONCURRENT_REQUESTS value",
+				fmt.Sprintf("UNLEASH_MAX_CONCURRENT_REQUESTS must be a positive integer, got %q", envValue),
+			)
+			return value
+		}
+		value = parsed
+	}
+
+	if !configValue.IsNull() && !configValue.IsUnknown() {
+		value = configValue.ValueInt64()
+	}
+
+	if value < 1 {
+		diagnostics.AddError(
+			"Invalid max_concurrent_requests value",
+			fmt.Sprintf("max_concurrent_requests must be at least 1, got %d", value),
+		)
+		return 2
+	}
+
+	return value
 }
 
 func terraformProviderAppName() string {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -36,8 +36,11 @@ type UnleashProvider struct {
 }
 
 const (
-	UserAgent            = "Terraform-Provider-Unleash"
-	unleashAppNameHeader = "X-Unleash-AppName"
+	UserAgent                     = "Terraform-Provider-Unleash"
+	unleashAppNameHeader          = "X-Unleash-AppName"
+	defaultMaxConcurrentRequests  = 2
+	maxConcurrentRequestsEnvVar   = "UNLEASH_MAX_CONCURRENT_REQUESTS"
+	maxConcurrentRequestsMaxValue = int64(int(^uint(0) >> 1))
 )
 
 // ScaffoldingProviderMofunc (p *UnleashProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {del describes the provider data model.
@@ -128,34 +131,44 @@ func mustHave(name string, value string, diagnostics *diag.Diagnostics) {
 	}
 }
 
-func maxConcurrentRequests(configValue basetypes.Int64Value, diagnostics *diag.Diagnostics) int64 {
-	value := int64(2)
+func maxConcurrentRequests(configValue basetypes.Int64Value, diagnostics *diag.Diagnostics) int {
+	if !configValue.IsNull() && !configValue.IsUnknown() {
+		return validateMaxConcurrentRequests("max_concurrent_requests", configValue.ValueInt64(), diagnostics)
+	}
 
-	if envValue := os.Getenv("UNLEASH_MAX_CONCURRENT_REQUESTS"); envValue != "" {
-		parsed, err := strconv.ParseInt(envValue, 10, 64)
+	if envValue := os.Getenv(maxConcurrentRequestsEnvVar); envValue != "" {
+		value, err := strconv.ParseInt(envValue, 10, 64)
 		if err != nil {
 			diagnostics.AddError(
-				"Invalid UNLEASH_MAX_CONCURRENT_REQUESTS value",
-				fmt.Sprintf("UNLEASH_MAX_CONCURRENT_REQUESTS must be a positive integer, got %q", envValue),
+				"Invalid "+maxConcurrentRequestsEnvVar+" value",
+				fmt.Sprintf("%s must be a positive integer, got %q", maxConcurrentRequestsEnvVar, envValue),
 			)
-			return value
+			return defaultMaxConcurrentRequests
 		}
-		value = parsed
+		return validateMaxConcurrentRequests(maxConcurrentRequestsEnvVar, value, diagnostics)
 	}
 
-	if !configValue.IsNull() && !configValue.IsUnknown() {
-		value = configValue.ValueInt64()
-	}
+	return defaultMaxConcurrentRequests
+}
 
+func validateMaxConcurrentRequests(name string, value int64, diagnostics *diag.Diagnostics) int {
 	if value < 1 {
 		diagnostics.AddError(
-			"Invalid max_concurrent_requests value",
-			fmt.Sprintf("max_concurrent_requests must be at least 1, got %d", value),
+			"Invalid "+name+" value",
+			fmt.Sprintf("%s must be at least 1, got %d", name, value),
 		)
-		return 2
+		return defaultMaxConcurrentRequests
 	}
 
-	return value
+	if value > maxConcurrentRequestsMaxValue {
+		diagnostics.AddError(
+			"Invalid "+name+" value",
+			fmt.Sprintf("%s must be less than or equal to %d, got %d", name, maxConcurrentRequestsMaxValue, value),
+		)
+		return defaultMaxConcurrentRequests
+	}
+
+	return int(value)
 }
 
 func terraformProviderAppName() string {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -75,10 +75,10 @@ func Test_provider_configValue(t *testing.T) {
 func Test_provider_maxConcurrentRequests(t *testing.T) {
 	var diags diag.Diagnostics
 
-	assert.Equal(t, int64(2), maxConcurrentRequests(types.Int64Null(), &diags))
+	assert.Equal(t, 2, maxConcurrentRequests(types.Int64Null(), &diags))
 	assert.False(t, diags.HasError())
 
-	assert.Equal(t, int64(4), maxConcurrentRequests(types.Int64Value(4), &diags))
+	assert.Equal(t, 4, maxConcurrentRequests(types.Int64Value(4), &diags))
 	assert.False(t, diags.HasError())
 }
 
@@ -87,14 +87,42 @@ func Test_provider_maxConcurrentRequests_env(t *testing.T) {
 
 	var diags diag.Diagnostics
 
-	assert.Equal(t, int64(3), maxConcurrentRequests(types.Int64Null(), &diags))
+	assert.Equal(t, 3, maxConcurrentRequests(types.Int64Null(), &diags))
 	assert.False(t, diags.HasError())
+}
+
+func Test_provider_maxConcurrentRequests_configOverridesInvalidEnv(t *testing.T) {
+	t.Setenv("UNLEASH_MAX_CONCURRENT_REQUESTS", "not-a-number")
+
+	var diags diag.Diagnostics
+
+	assert.Equal(t, 4, maxConcurrentRequests(types.Int64Value(4), &diags))
+	assert.False(t, diags.HasError())
+}
+
+func Test_provider_maxConcurrentRequests_env_rejectsNonNumericValue(t *testing.T) {
+	t.Setenv("UNLEASH_MAX_CONCURRENT_REQUESTS", "not-a-number")
+
+	var diags diag.Diagnostics
+
+	assert.Equal(t, 2, maxConcurrentRequests(types.Int64Null(), &diags))
+	assert.True(t, diags.HasError())
+}
+
+func Test_provider_maxConcurrentRequests_env_rejectsInvalidValues(t *testing.T) {
+	t.Setenv("UNLEASH_MAX_CONCURRENT_REQUESTS", "0")
+
+	var diags diag.Diagnostics
+
+	assert.Equal(t, 2, maxConcurrentRequests(types.Int64Null(), &diags))
+	assert.True(t, diags.HasError())
+	assert.Contains(t, diags[0].Summary(), "UNLEASH_MAX_CONCURRENT_REQUESTS")
 }
 
 func Test_provider_maxConcurrentRequests_rejectsInvalidValues(t *testing.T) {
 	var diags diag.Diagnostics
 
-	assert.Equal(t, int64(2), maxConcurrentRequests(types.Int64Value(0), &diags))
+	assert.Equal(t, 2, maxConcurrentRequests(types.Int64Value(0), &diags))
 	assert.True(t, diags.HasError())
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -72,6 +72,32 @@ func Test_provider_configValue(t *testing.T) {
 	assert.Equal(t, "bar", configValue(types.StringNull(), "QUX", "BAR", "BAZ"))
 }
 
+func Test_provider_maxConcurrentRequests(t *testing.T) {
+	var diags diag.Diagnostics
+
+	assert.Equal(t, int64(2), maxConcurrentRequests(types.Int64Null(), &diags))
+	assert.False(t, diags.HasError())
+
+	assert.Equal(t, int64(4), maxConcurrentRequests(types.Int64Value(4), &diags))
+	assert.False(t, diags.HasError())
+}
+
+func Test_provider_maxConcurrentRequests_env(t *testing.T) {
+	t.Setenv("UNLEASH_MAX_CONCURRENT_REQUESTS", "3")
+
+	var diags diag.Diagnostics
+
+	assert.Equal(t, int64(3), maxConcurrentRequests(types.Int64Null(), &diags))
+	assert.False(t, diags.HasError())
+}
+
+func Test_provider_maxConcurrentRequests_rejectsInvalidValues(t *testing.T) {
+	var diags diag.Diagnostics
+
+	assert.Equal(t, int64(2), maxConcurrentRequests(types.Int64Value(0), &diags))
+	assert.True(t, diags.HasError())
+}
+
 func Test_unleashClient_setsUnleashHeaders(t *testing.T) {
 	ctx := context.Background()
 	p := &UnleashProvider{version: "1.2.3"}


### PR DESCRIPTION
## Summary

This adds provider-side throttling for requests sent to the Unleash API. Terraform can evaluate independent resources concurrently, and its default parallelism can produce more simultaneous API requests than smaller Unleash deployments can safely handle. In particular, deployments with small database connection pools may start returning transient 5xx errors before users realize Terraform concurrency is the trigger.

The provider now limits concurrent HTTP requests to `2` by default. This gives Unleash a conservative default that matches constrained backend capacity without requiring every customer to remember to run Terraform with `-parallelism=2`.

## Details

- Adds a shared HTTP transport semaphore around the generated Unleash API client.
- Holds each semaphore slot until the response body is closed, so the limit reflects active in-flight API work.
- Adds an optional `max_concurrent_requests` provider setting.
- Adds `UNLEASH_MAX_CONCURRENT_REQUESTS` as an environment variable override.
- Documents that `2` is the recommended default and that increasing the value can overload deployments with small connection pools.

## Testing

- `go test ./internal/provider`
- `go test ./...`
