### PR TITLE
feat: add shim package re-exporting the provider constructor

### DIFF
--- a/shim/shim.go
+++ b/shim/shim.go
@@ -1,0 +1,23 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package shim exposes the provider constructor to external Go modules.
+//
+// The provider implementation lives in internal/provider, which Go's module
+// visibility rules make unimportable from outside this repository. Re-exporting
+// New here lets external tooling embed the provider directly — in particular a
+// Pulumi provider built on the Pulumi Terraform Bridge, which must construct the
+// terraform-plugin-framework provider to generate its schema and language SDKs.
+package shim
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+
+	internalprovider "github.com/Unleash/terraform-provider-unleash/internal/provider"
+)
+
+// New returns the Unleash provider constructor, identical to the one used by
+// the provider's own main entrypoint.
+func New(version string) func() provider.Provider {
+	return internalprovider.New(version)
+}


### PR DESCRIPTION
## What

Adds a small `shim` package that re-exports the provider constructor `New` from
`internal/provider`. One new file (`shim/shim.go`); no existing file is changed.

## Why

The provider implementation lives in `internal/provider`, so Go's module
visibility rules prevent any code outside this repository from constructing it.
The [Pulumi Terraform Bridge](https://github.com/pulumi/pulumi-terraform-bridge)
(and similar tooling) needs to instantiate the `terraform-plugin-framework`
provider in order to generate a schema and language SDKs from it.

Re-exporting `New` through a non-internal `shim` package unblocks building a
**Pulumi provider for Unleash** on top of this Terraform provider — reusing all
of your existing resource and data-source definitions, so the two stay in
lockstep automatically as the provider evolves.

## Scope / safety

- **Zero behavior change.** `shim.New` returns exactly what `main.go` already
  passes to `providerserver.Serve` today.
- **Additive only.** No existing file is touched; nothing is moved out of
  `internal/`.

## Follow-up (optional — happy to discuss)

If you're open to it, we'd like to follow this with a full `pulumi-unleash`
provider bridged from this repo, and ideally contribute it to the Unleash org so
it lives alongside the Terraform provider. This PR is the minimal enabling step
and stands on its own regardless of where that conversation lands.
