### PR TITLE
docs: import examples and tests + how to release

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ make testacc
 - `golangci-lint run --fix` to lint the code (You can install it with `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`)
 - `go generate ./...` to update docs
 
+## Releasing
+
+Releases are handled by GitHub Actions and GoReleaser. The release workflow in `.github/workflows/release.yml` runs when a tag matching `v*` is pushed, for example `v3.4.2`.
+
+The normal release flow is:
+
+1. Make sure the intended release commit is on `main` and CI is green.
+1. Open [GitHub releases](https://github.com/Unleash/terraform-provider-unleash/releases) and draft a new release.
+1. Set the tag to the new semantic version, prefixed with `v`, for example `v3.4.2`, targeting `main`.
+1. Publish the release.
+1. The pushed tag triggers the `Release` workflow, which runs GoReleaser, builds the provider artifacts, signs the checksums with the configured GPG key, and uploads the release assets.
+
 ## Using the provider
 
 Fill this in for each provider

--- a/docs/resources/context_field.md
+++ b/docs/resources/context_field.md
@@ -13,6 +13,11 @@ Fetch a context field.
 ## Example Usage
 
 ```terraform
+import {
+  id = "ham"
+  to = unleash_context_field.ham_context_field
+}
+
 resource "unleash_context_field" "ham_context_field" {
   name = "ham"
 }

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -13,6 +13,11 @@ Manage Unleash environments.
 ## Example Usage
 
 ```terraform
+import {
+  id = "outerspace"
+  to = unleash_environment.space
+}
+
 resource "unleash_environment" "space" {
   name = "outerspace"
   type = "vacuum"

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -13,6 +13,11 @@ Manage an Unleash group. The mappings_sso attribute contains external SSO/IdP gr
 ## Example Usage
 
 ```terraform
+import {
+  id = "1"
+  to = unleash_group.team
+}
+
 resource "unleash_user" "group_member" {
   email      = "group-member@example.com"
   name       = "Group Member"

--- a/docs/resources/project_environment.md
+++ b/docs/resources/project_environment.md
@@ -13,6 +13,11 @@ ProjectEnvironment schema
 ## Example Usage
 
 ```terraform
+import {
+  id = "one:outerspace"
+  to = unleash_project_environment.space_environment
+}
+
 resource "unleash_project" "project_1" {
   id          = "one"
   name        = "First project"

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -13,6 +13,11 @@ Role schema
 ## Example Usage
 
 ```terraform
+import {
+  id = "1"
+  to = unleash_role.custom_root_role
+}
+
 resource "unleash_role" "custom_root_role" {
   name        = "A custom role"
   type        = "root-custom"
@@ -24,7 +29,7 @@ resource "unleash_role" "custom_root_role" {
   }]
 }
 
-resource "unleash_role" "custom_root_role" {
+resource "unleash_role" "renamed_custom_root_role" {
   name        = "Renamed custom role"
   type        = "root-custom"
   description = "A custom test root role"

--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -22,14 +22,19 @@ Service accounts do nothing on their own, they need service account tokens to be
 ## Example Usage
 
 ```terraform
+import {
+  id = 1
+  to = unleash_service_account.admin_service_account
+}
+
 data "unleash_role" "admin_role" {
   name = "Admin"
 }
 
-resource "unleash_service_account" "admin service account" {
+resource "unleash_service_account" "admin_service_account" {
   name      = "something unique"
   username  = "something unique"
-  root_role = admin_role.id
+  root_role = data.unleash_role.admin_role.id
 }
 ```
 

--- a/examples/resources/unleash_context_field/resource.tf
+++ b/examples/resources/unleash_context_field/resource.tf
@@ -1,3 +1,8 @@
+import {
+  id = "ham"
+  to = unleash_context_field.ham_context_field
+}
+
 resource "unleash_context_field" "ham_context_field" {
   name = "ham"
 }

--- a/examples/resources/unleash_environment/resource.tf
+++ b/examples/resources/unleash_environment/resource.tf
@@ -1,3 +1,8 @@
+import {
+  id = "outerspace"
+  to = unleash_environment.space
+}
+
 resource "unleash_environment" "space" {
   name = "outerspace"
   type = "vacuum"

--- a/examples/resources/unleash_group/resource.tf
+++ b/examples/resources/unleash_group/resource.tf
@@ -1,3 +1,8 @@
+import {
+  id = "1"
+  to = unleash_group.team
+}
+
 resource "unleash_user" "group_member" {
   email      = "group-member@example.com"
   name       = "Group Member"

--- a/examples/resources/unleash_project_environment/resource.tf
+++ b/examples/resources/unleash_project_environment/resource.tf
@@ -1,3 +1,8 @@
+import {
+  id = "one:outerspace"
+  to = unleash_project_environment.space_environment
+}
+
 resource "unleash_project" "project_1" {
   id          = "one"
   name        = "First project"

--- a/examples/resources/unleash_role/resource.tf
+++ b/examples/resources/unleash_role/resource.tf
@@ -1,3 +1,8 @@
+import {
+  id = "1"
+  to = unleash_role.custom_root_role
+}
+
 resource "unleash_role" "custom_root_role" {
   name        = "A custom role"
   type        = "root-custom"
@@ -9,7 +14,7 @@ resource "unleash_role" "custom_root_role" {
   }]
 }
 
-resource "unleash_role" "custom_root_role" {
+resource "unleash_role" "renamed_custom_root_role" {
   name        = "Renamed custom role"
   type        = "root-custom"
   description = "A custom test root role"

--- a/examples/resources/unleash_service_account/resource.tf
+++ b/examples/resources/unleash_service_account/resource.tf
@@ -1,9 +1,14 @@
+import {
+  id = 1
+  to = unleash_service_account.admin_service_account
+}
+
 data "unleash_role" "admin_role" {
   name = "Admin"
 }
 
-resource "unleash_service_account" "admin service account" {
+resource "unleash_service_account" "admin_service_account" {
   name      = "something unique"
   username  = "something unique"
-  root_role = admin_role.id
+  root_role = data.unleash_role.admin_role.id
 }

--- a/internal/provider/context_field_resource_test.go
+++ b/internal/provider/context_field_resource_test.go
@@ -93,6 +93,13 @@ func TestAccContextFieldResource(t *testing.T) {
 					resource.TestCheckResourceAttr("unleash_context_field.cheese_context_field", "legal_values.0.description", "More gooey, more delicious"),
 				),
 			},
+			{
+				ResourceName:                         "unleash_context_field.cheese_context_field",
+				ImportStateId:                        "cheese_monger_stock",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "name",
+			},
 		},
 	})
 }

--- a/internal/provider/environment_resource_test.go
+++ b/internal/provider/environment_resource_test.go
@@ -51,6 +51,13 @@ func TestAccEnvironmentResource(t *testing.T) {
 					resource.TestCheckResourceAttr("unleash_environment.fynbos_environment", "type", "semi-desert"),
 				),
 			},
+			{
+				ResourceName:                         "unleash_environment.fynbos_environment",
+				ImportStateId:                        "nama_karoo",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "name",
+			},
 		},
 	})
 }

--- a/internal/provider/project_access_resource_test.go
+++ b/internal/provider/project_access_resource_test.go
@@ -118,6 +118,13 @@ func TestAccProjectAccessResource(t *testing.T) {
 					resource.TestCheckResourceAttr("unleash_project_access.sample_project_access", "roles.1.users.#", "1"),
 				),
 			},
+			{
+				ResourceName:                         "unleash_project_access.sample_project_access",
+				ImportStateId:                        "sample",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "project",
+			},
 		},
 	})
 }

--- a/internal/provider/service_account_resource_test.go
+++ b/internal/provider/service_account_resource_test.go
@@ -31,11 +31,6 @@ func TestAccServiceAccountResource(t *testing.T) {
 					resource.TestCheckResourceAttr("unleash_service_account.test_service_account", "root_role", "1"),
 				),
 			},
-			{
-				ResourceName:      "unleash_service_account.test_service_account",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }

--- a/internal/provider/service_account_resource_test.go
+++ b/internal/provider/service_account_resource_test.go
@@ -31,6 +31,11 @@ func TestAccServiceAccountResource(t *testing.T) {
 					resource.TestCheckResourceAttr("unleash_service_account.test_service_account", "root_role", "1"),
 				),
 			},
+			{
+				ResourceName:      "unleash_service_account.test_service_account",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
# About the changes

This adds missing Terraform import examples for importable resources whose docs did not show how to import them. The generated provider docs were refreshed from the examples.

Included resources:

- `unleash_context_field`
- `unleash_environment`
- `unleash_group`
- `unleash_project_environment`
- `unleash_role`
- `unleash_service_account`

This also adds acceptance import coverage for resources that had import support but no import test path yet:

- `unleash_context_field`
- `unleash_environment`
- `unleash_project_access`

Finally, the README now documents the release flow: publish a GitHub release with a new `vX.Y.Z` tag targeting `main`; the tag push triggers the existing Release workflow and GoReleaser publishes the provider artifacts.

`unleash_service_account_token` is intentionally left out of the new import examples. Its current importer behavior needs a separate decision about the intended import contract before documenting it.

Closes #91

# Testing

- `go generate ./...`
- `go test ./internal/provider`
- `terraform fmt -check -recursive examples`
- `git diff --check`