### PR TITLE
fix: add /v3 suffix to the Go module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Unleash/terraform-provider-unleash
+module github.com/Unleash/terraform-provider-unleash/v3
 
 go 1.24.0
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/Unleash/terraform-provider-unleash/internal/provider"
+	"github.com/Unleash/terraform-provider-unleash/v3/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 )
 

--- a/shim/shim.go
+++ b/shim/shim.go
@@ -13,7 +13,7 @@ package shim
 import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 
-	internalprovider "github.com/Unleash/terraform-provider-unleash/internal/provider"
+	internalprovider "github.com/Unleash/terraform-provider-unleash/v3/internal/provider"
 )
 
 // New returns the Unleash provider constructor, identical to the one used by


### PR DESCRIPTION
## What

One-line change to `go.mod`, plus the two internal imports that follow from it:

```diff
-module github.com/Unleash/terraform-provider-unleash
+module github.com/Unleash/terraform-provider-unleash/v3
```

3 files, 3 insertions, 3 deletions.

## Why

Releases are tagged `v3.x`, but `go.mod` declares the unsuffixed path. Go requires the
major-version suffix from v2 onward, so **every `v2.x` and `v3.x` tag is unresolvable as a
dependency**:

```
$ go get github.com/Unleash/terraform-provider-unleash@v3.4.2
invalid version: module contains a go.mod file, so module path must match
major version ("github.com/Unleash/terraform-provider-unleash/v3")
```

The `/v3` path fails too, from the other side (`go.mod has non-.../v3 module path
"github.com/Unleash/terraform-provider-unleash"`). Consequently the module proxy's `@latest` is
pinned at **v1.4.1 (March 2025)** — every release since is invisible to Go tooling.

This also makes #307 incomplete: the `shim` package is exported, but unreachable at any released
version.

## Nothing can break

Unusually for a module-path change, the blast radius is provably zero — **no consumer can currently
depend on v2 or v3**, because the proxy rejects those tags outright. There is no working dependency
to break.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l` — all clean
- The GitHub URL in `internal/provider/provider.go:110` and the `terraform-provider-unleash`
  TypeName at `provider.go:175` are deliberately untouched — neither is a module path
- `.goreleaser.yml` uses `-X main.version=`, which is package-relative, so release tooling needs no
  changes
- **End-to-end**: an external module importing `github.com/Unleash/terraform-provider-unleash/v3/shim`
  now compiles and constructs the provider — the thing #307 set out to enable:

  ```
  constructed provider: *provider.UnleashProvider
  ```

## Note

This takes effect from the next tag onward; already-published `v3.x` tags can't be retroactively
fixed. A `v3.4.3` (or whatever comes next) would be the first Go-consumable v3.

## Context

I'm building a Pulumi provider bridged from this one, which is what surfaced this. It's the reason
#307 existed, and it currently has to pin a pseudo-version instead of a release tag because of the
module path. Happy to leave that detail out of scope here — this change stands on its own for any Go
consumer.
