### PR TITLE
fix: add /v3 suffix to Go module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Unleash/terraform-provider-unleash
+module github.com/Unleash/terraform-provider-unleash/v3
 
 go 1.24.0
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/Unleash/terraform-provider-unleash/internal/provider"
+	"github.com/Unleash/terraform-provider-unleash/v3/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 )
 

--- a/shim/shim.go
+++ b/shim/shim.go
@@ -13,7 +13,7 @@ package shim
 import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 
-	internalprovider "github.com/Unleash/terraform-provider-unleash/internal/provider"
+	internalprovider "github.com/Unleash/terraform-provider-unleash/v3/internal/provider"
 )
 
 // New returns the Unleash provider constructor, identical to the one used by


### PR DESCRIPTION
Mirrors external PR #311 to run repository CI with access to internal secrets.

Source PR: https://github.com/Unleash/terraform-provider-unleash/pull/311
Source branch: hagaym1:feat/v3-module-path

Changes:
- Updates the Go module path to github.com/Unleash/terraform-provider-unleash/v3.
- Updates internal imports in main.go and shim/shim.go to match the module path.

Local validation:
- go list ./...
- go test ./...